### PR TITLE
Highlight 'AST-based' in README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">light weight MCP for code that just works </h1>
 
 
-A super light-weight, effective embedded MCP (AST-based) that understand and searches your codebase that just works! Using [CocoIndex](https://github.com/cocoindex-io/cocoindex) - an Rust-based ultra performant data transformation engine. No blackbox. Works for Claude, Codex, Cursor - any coding agent.
+A super light-weight, effective embedded MCP **(AST-based)** that understand and searches your codebase that just works! Using [CocoIndex](https://github.com/cocoindex-io/cocoindex) - an Rust-based ultra performant data transformation engine. No blackbox. Works for Claude, Codex, Cursor - any coding agent.
 
 - Instant token saving by 70%.
 - **1 min setup** - Just claude/codex mcp add works!


### PR DESCRIPTION
Emphasize 'AST-based' in the description for clarity.