### PR TITLE
Fix trailing whitespace in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ codex mcp add cocoindex-code \
 
 ### OpenCode
 ```bash
-opencode mcp add 
+opencode mcp add
 ```
 Enter MCP server name: `cocoindex-code`
 Select MCP server type: `local`


### PR DESCRIPTION
Remove trailing space on line 52 (opencode mcp add) that was causing the pre-commit trailing-whitespace hook to fail.