### PR TITLE
Fix trailing whitespace in README.md causing prek CI failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A super light-weight, effective embedded MCP **(AST-based)** that understand and
 - **1 min setup** - Just claude/codex mcp add works!
 
 <div align="center">
-  
+
 [![Discord](https://img.shields.io/discord/1314801574169673738?logo=discord&color=5B5BD6&logoColor=white)](https://discord.com/invite/zpA9S2DR7s)
 [![GitHub](https://img.shields.io/github/stars/cocoindex-io/cocoindex?color=5B5BD6)](https://github.com/cocoindex-io/cocoindex)
 [![Documentation](https://img.shields.io/badge/Documentation-394e79?logo=readthedocs&logoColor=00B9FF)](https://cocoindex.io/docs/getting_started/quickstart)


### PR DESCRIPTION
Remove trailing space on blank line inside the badge `<div>` block.