### PR TITLE
Add php files to indexer

### DIFF
--- a/src/cocoindex_code/indexer.py
+++ b/src/cocoindex_code/indexer.py
@@ -50,6 +50,7 @@ EXCLUDED_PATTERNS = [
     "**/build/assets",  # Build asserts directories
     "**/dist",  # Distribution directories
     "**/vendor/*.*/*",  # Go vendor directory (domain-based paths)
+    "**/vendor/*",  # PHP vendor directory
     "**/.cocoindex_code",  # Our own index directory
 ]
 


### PR DESCRIPTION
As cocoindex supports PHP, and the cocoindex-code README mentions php support, all that was missing was the indexer actually indexing php files.

This very small PR adds .php files to the indexer while excluding composer libraries in vendor
