### PR TITLE
Support extra extensions with optional language mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Optionally, you can run `cocoindex-code index` to create or update the index. Wi
 | `COCOINDEX_CODE_ROOT_PATH` | Root path of the codebase | Auto-discovered (see below) |
 | `COCOINDEX_CODE_EMBEDDING_MODEL` | Embedding model (see below) | `sbert/sentence-transformers/all-MiniLM-L6-v2` |
 | `COCOINDEX_CODE_BATCH_SIZE` | Max batch size for local embedding model | `16` |
-| `COCOINDEX_CODE_EXTRA_EXTENSIONS` | Additional file extensions to index (comma-separated, e.g. `"rb,yaml,toml"`) | _(none)_ |
+| `COCOINDEX_CODE_EXTRA_EXTENSIONS` | Additional file extensions to index (comma-separated, e.g. `"inc:php,yaml,toml"` — use `ext:lang` to override language detection) | _(none)_ |
 
 
 ### Root Path Discovery

--- a/src/cocoindex_code/config.py
+++ b/src/cocoindex_code/config.py
@@ -66,7 +66,7 @@ class Config:
     device: str
     trust_remote_code: bool
     batch_size: int
-    extra_extensions: list[str]
+    extra_extensions: dict[str, str | None]
 
     @classmethod
     def from_env(cls) -> Config:
@@ -114,13 +114,18 @@ class Config:
                 f"COCOINDEX_CODE_BATCH_SIZE must be a positive integer, got: {batch_size}"
             )
 
-        # Extra file extensions
+        # Extra file extensions (format: "inc:php,yaml,toml" — optional lang after colon)
         raw_extra = os.environ.get("COCOINDEX_CODE_EXTRA_EXTENSIONS", "")
-        extra_extensions: list[str] = []
-        for ext in raw_extra.split(","):
-            ext = ext.strip()
-            if ext:
-                extra_extensions.append(f".{ext}")
+        extra_extensions: dict[str, str | None] = {}
+        for token in raw_extra.split(","):
+            token = token.strip()
+            if not token:
+                continue
+            if ":" in token:
+                ext, lang = token.split(":", 1)
+                extra_extensions[f".{ext.strip()}"] = lang.strip() or None
+            else:
+                extra_extensions[f".{token}"] = None
 
         return cls(
             codebase_root_path=root,

--- a/src/cocoindex_code/indexer.py
+++ b/src/cocoindex_code/indexer.py
@@ -46,6 +46,11 @@ DEFAULT_INCLUDED_PATTERNS = [
 
 INCLUDED_PATTERNS = DEFAULT_INCLUDED_PATTERNS + [f"**/*{ext}" for ext in config.extra_extensions]
 
+# Language overrides from extra_extensions (e.g. ".inc" -> "php")
+LANGUAGE_OVERRIDES: dict[str, str] = {
+    ext: lang for ext, lang in config.extra_extensions.items() if lang is not None
+}
+
 EXCLUDED_PATTERNS = [
     "**/.*",  # Hidden directories
     "**/__pycache__",  # Python cache
@@ -84,7 +89,12 @@ async def process_file(
         return
 
     # Get relative path and detect language
-    language = detect_code_language(filename=file.file_path.path.name) or "text"
+    suffix = file.file_path.path.suffix
+    language = (
+        LANGUAGE_OVERRIDES.get(suffix)
+        or detect_code_language(filename=file.file_path.path.name)
+        or "text"
+    )
 
     # Split into chunks
     chunks = splitter.split(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -150,7 +150,7 @@ class TestExtraExtensions:
         ):
             os.environ.pop("COCOINDEX_CODE_EXTRA_EXTENSIONS", None)
             config = Config.from_env()
-            assert config.extra_extensions == []
+            assert config.extra_extensions == {}
 
     def test_parses_comma_separated(self, tmp_path: Path) -> None:
         with patch.dict(
@@ -161,7 +161,7 @@ class TestExtraExtensions:
             },
         ):
             config = Config.from_env()
-            assert config.extra_extensions == [".rb", ".yaml", ".toml"]
+            assert config.extra_extensions == {".rb": None, ".yaml": None, ".toml": None}
 
     def test_trims_whitespace(self, tmp_path: Path) -> None:
         with patch.dict(
@@ -172,9 +172,9 @@ class TestExtraExtensions:
             },
         ):
             config = Config.from_env()
-            assert config.extra_extensions == [".rb", ".yaml"]
+            assert config.extra_extensions == {".rb": None, ".yaml": None}
 
-    def test_empty_string_gives_empty_list(self, tmp_path: Path) -> None:
+    def test_empty_string_gives_empty_dict(self, tmp_path: Path) -> None:
         with patch.dict(
             os.environ,
             {
@@ -183,7 +183,7 @@ class TestExtraExtensions:
             },
         ):
             config = Config.from_env()
-            assert config.extra_extensions == []
+            assert config.extra_extensions == {}
 
     def test_dot_prefix_passed_through(self, tmp_path: Path) -> None:
         with patch.dict(
@@ -194,4 +194,26 @@ class TestExtraExtensions:
             },
         ):
             config = Config.from_env()
-            assert config.extra_extensions == ["..rb", ".yaml"]
+            assert config.extra_extensions == {"..rb": None, ".yaml": None}
+
+    def test_parses_lang_mapping(self, tmp_path: Path) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "COCOINDEX_CODE_ROOT_PATH": str(tmp_path),
+                "COCOINDEX_CODE_EXTRA_EXTENSIONS": "inc:php",
+            },
+        ):
+            config = Config.from_env()
+            assert config.extra_extensions == {".inc": "php"}
+
+    def test_mixed_with_and_without_lang(self, tmp_path: Path) -> None:
+        with patch.dict(
+            os.environ,
+            {
+                "COCOINDEX_CODE_ROOT_PATH": str(tmp_path),
+                "COCOINDEX_CODE_EXTRA_EXTENSIONS": "inc:php,yaml,tpl:html",
+            },
+        ):
+            config = Config.from_env()
+            assert config.extra_extensions == {".inc": "php", ".yaml": None, ".tpl": "html"}


### PR DESCRIPTION
## Background

Some legacy PHP projects use `.inc` as a file extension, but it is currently not indexed and therefore excluded from code search.

## Changes

1. Add support for extra extensions (1st commit)

Users can now specify additional file extensions to index via the `COCOINDEX_CODE_EXTRA_EXTENSIONS` environment variable.

`COCOINDEX_CODE_EXTRA_EXTENSIONS="inc,tpl"`

2. Add language mapping support (2nd commit)

Language detection is handled by the `detect_code_language` function in cocoindex, but some extensions like `.inc` are not tied to a specific language. To handle this, users can now specify the language explicitly using the `ext:lang` format to override detection.

`COCOINDEX_CODE_EXTRA_EXTENSIONS="inc:php,yaml,tpl:html"`

When no language is specified, it falls back to `detect_code_language` as before.

## Note
Language mapping is currently handled on the caller side. If there is a better place for this (e.g. extending `detect_code_language`), I'm happy to adjust the approach.

## Tests

All 20 tests pass