### PR TITLE
feat: add Lua language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Returns matching code chunks with:
 | javascript | js | `.js` |
 | json | | `.json` |
 | kotlin | | `.kt`, `.kts` |
+| lua | | `.lua` |
 | markdown | md | `.md`, `.mdx` |
 | pascal | pas, dpr, delphi | `.pas`, `.dpr` |
 | php | | `.php` |

--- a/src/cocoindex_code/indexer.py
+++ b/src/cocoindex_code/indexer.py
@@ -42,6 +42,7 @@ DEFAULT_INCLUDED_PATTERNS = [
     "**/*.txt",  # Plain text
     "**/*.rst",  # reStructuredText
     "**/*.php",  # PHP
+    "**/*.lua",  # Lua
 ]
 
 INCLUDED_PATTERNS = DEFAULT_INCLUDED_PATTERNS + [f"**/*{ext}" for ext in config.extra_extensions]


### PR DESCRIPTION
Add .lua files to DEFAULT_INCLUDED_PATTERNS to enable automatic indexing of Lua code. The underlying cocoindex library already supports Lua language detection, this change makes it available by default without requiring COCOINDEX_CODE_EXTRA_EXTENSIONS.

Changes:
- Add **/*.lua to DEFAULT_INCLUDED_PATTERNS in indexer.py
- Add Lua to supported languages table in README.md