### PR TITLE
chore: upgrade cocoindex and fix args to `embed()` call

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     "mcp>=1.0.0",
-    "cocoindex[litellm]==1.0.0a28",
+    "cocoindex[litellm]==1.0.0a29",
     "sentence-transformers>=2.2.0",
     "sqlite-vec>=0.1.0",
     "pydantic>=2.0.0",

--- a/src/cocoindex_code/query.py
+++ b/src/cocoindex_code/query.py
@@ -106,7 +106,7 @@ async def query_codebase(
     db = coco_env.get_context(SQLITE_DB)
 
     # Generate query embedding.
-    query_embedding = await embedder.embed(query, True, query_prompt_name)
+    query_embedding = await embedder.embed(query, query_prompt_name)
 
     embedding_bytes = query_embedding.astype("float32").tobytes()
 

--- a/uv.lock
+++ b/uv.lock
@@ -330,7 +330,7 @@ wheels = [
 
 [[package]]
 name = "cocoindex"
-version = "1.0.0a28"
+version = "1.0.0a29"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -341,17 +341,17 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0f/3b/67eb06371a9afc114db0262c92de099c859f07605d87f4450e21de694652/cocoindex-1.0.0a28.tar.gz", hash = "sha256:654760c3fa06e4d76c2c215e82f3f59cbd6ec22206d4fc2c173ba1b10e056e80", size = 287577, upload-time = "2026-03-12T16:23:39.812Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/c4/ca9b256b9a1b52f752251fbd7e88f4ce2b540c2b92a3fcec23f3d250d30a/cocoindex-1.0.0a29.tar.gz", hash = "sha256:879840dec53f5f07aa26ebfed97005668b3ee594f982508e05df9bed19016b70", size = 288151, upload-time = "2026-03-13T00:44:51.906Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/15/5f/bf0eb7a549698479e831cce77a1d4cc872550c55aaad407ca120aca048cf/cocoindex-1.0.0a28-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c4806afb416a0ddd413653c207f4f5b886d0f404aa6348a214f9092532d7e8f2", size = 6245639, upload-time = "2026-03-12T16:23:37.616Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/66/7c11f9aa2b71862b493b90f670a821db0ac8c5920689c0f042a574f67f2c/cocoindex-1.0.0a28-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:5948e074af59842096214e251a0940c8ea6313b35dfa81b7c9567b08ec4df9c4", size = 6364193, upload-time = "2026-03-12T16:23:33.39Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/00/f91ed32a67511280f75194cfd337e1699484630b56d4f0d2d6757495dd44/cocoindex-1.0.0a28-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:efa2c67b90a4032815b7eb2e051f83de466135657acae034e561d177ef7f7f80", size = 6154059, upload-time = "2026-03-12T16:23:23.684Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/a8/58a5db98239b7371a6d6d6d8611577b3fc38ba967ea40a51d1c702229dff/cocoindex-1.0.0a28-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:9aa2b258d824db25737d98dcc8e7a2c20828e4838deff1f3d4b3aa37ab3e6ef9", size = 6348023, upload-time = "2026-03-12T16:23:28.411Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/6e/7f6303e9c21eead537a552d63bae00a8546c8744825ef45ec7b99cda4457/cocoindex-1.0.0a28-cp311-abi3-win_amd64.whl", hash = "sha256:e49af896f5cb61df0b0249ecee00ef44a10e94f5c442b91f5bfe505e91913b35", size = 6526692, upload-time = "2026-03-12T16:23:41.329Z" },
-    { url = "https://files.pythonhosted.org/packages/87/df/6bab4865ef1e1771dfd3900cef2432692349da3052bdbd27949fea8241fa/cocoindex-1.0.0a28-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9b551874c663cc0fe5eb2c93b3e13b108b7d6351f3a4614ca65b66716b025b01", size = 6363326, upload-time = "2026-03-12T16:23:35.707Z" },
-    { url = "https://files.pythonhosted.org/packages/58/2b/1df48ae492cbfd84fbfd8dc9e18b8ad55b91b04a8d8b1c902af0f43684a4/cocoindex-1.0.0a28-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6a222844a6f5e6808457f603253d8d3982dec205c3feeeb68a8fe95d71416c22", size = 6153789, upload-time = "2026-03-12T16:23:26.275Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/3c/90723c9efd6a8c6778211feaeebcfe7eb2d05b6b61f0d25de7df4020c2ba/cocoindex-1.0.0a28-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a182c0d85957c1c6aa06cf5041833abbc9d0877effb7c7817d262ae0a9a033b1", size = 6344670, upload-time = "2026-03-12T16:23:30.899Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/1e/5930ef7e75c2da06eb72031cc034dc711af9159d8b8ee78bbeaaaf089a76/cocoindex-1.0.0a28-cp314-cp314t-win_amd64.whl", hash = "sha256:2855c7dec01db86be3d3d439c96cb571fbbcca19807de7abaabf83c3c7cfcd5c", size = 6522884, upload-time = "2026-03-12T16:23:43.374Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/5b/09a2fb74ac5dd68f43355e6f7653d3a02271176b05de76edc75e2366b67f/cocoindex-1.0.0a29-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:54cac1a57aa68a6cb78568785d85cfec2f7dfa0703d38d74557ab63221455118", size = 6247093, upload-time = "2026-03-13T00:44:50.014Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/a6/a84a61b91a89848c1f70f92499a8f6578e48e52808b91f1d0bc54adb0499/cocoindex-1.0.0a29-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:954769ecd274dd23c0dac2a1375121d52387a653b84c001d44bcc04096ee36e7", size = 6365382, upload-time = "2026-03-13T00:44:45.826Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/eb/87c78ac105c78aaf8cd7455e2caac6df8f6858ec369c00ddee58dd921262/cocoindex-1.0.0a29-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:41b4baa5afe425f61fe5179618eefcfcfe8c16debc4182f2b546d95b8e56c2b5", size = 6154033, upload-time = "2026-03-13T00:44:36.9Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/6f/63b88b93fa9565622797d33168b58007a4668518aa222deb50ba98a1767c/cocoindex-1.0.0a29-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:87ab220940bdd3fc956f58bab5ceac78245c41481ed96c06bc22aabbb430032d", size = 6347118, upload-time = "2026-03-13T00:44:41.468Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/4c/24b04b9e9f331b6ca83a73919b84f085e4c6dab85577d08fea35b50c4295/cocoindex-1.0.0a29-cp311-abi3-win_amd64.whl", hash = "sha256:5970d9554c664c402ed728104e10bf0ac6691f6a12632d81461809e475409587", size = 6527139, upload-time = "2026-03-13T00:44:53.691Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5c/e60d526db051df98970b1d31c8f5f43d24e34a3aa78a222dc8adcedc71f8/cocoindex-1.0.0a29-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6c69b2df02f2111b8f8e2c57563169e8eb2810e427212731c7ddeedf1a4e57ae", size = 6362756, upload-time = "2026-03-13T00:44:47.892Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/ee/19f865d0a6c365bf94d057423cff56f9f60730fa827c5d25ae72061db332/cocoindex-1.0.0a29-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:33139c6c32e1e5acb33791d77e7b5e6f08c4012100ee703958ce57f3ed9c4b84", size = 6154611, upload-time = "2026-03-13T00:44:39.267Z" },
+    { url = "https://files.pythonhosted.org/packages/48/00/d86379ca337300ddfcbc0473b1c54e55ece734c14861f0868ca1c831f78c/cocoindex-1.0.0a29-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a09cdd0d321c9e5c4ec3deb1fc4c3ab3cd5403f6af47f62b6017223755acb12c", size = 6342766, upload-time = "2026-03-13T00:44:43.881Z" },
+    { url = "https://files.pythonhosted.org/packages/86/73/5bc47eb075ec21a5004d0420897b567478ec8f50dd12a685d818b25437d2/cocoindex-1.0.0a29-cp314-cp314t-win_amd64.whl", hash = "sha256:19c2ea8584fe29bf62de076a57a5befcec17167458fc21b1138b041baa9c0973", size = 6523794, upload-time = "2026-03-13T00:44:55.884Z" },
 ]
 
 [package.optional-dependencies]
@@ -394,7 +394,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cocoindex", extras = ["litellm"], specifier = "==1.0.0a28" },
+    { name = "cocoindex", extras = ["litellm"], specifier = "==1.0.0a29" },
     { name = "einops", specifier = ">=0.8.2" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },


### PR DESCRIPTION
Fixes #58