### PR TITLE
feat: add Docker support with ghcr.io publish workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,105 @@ ccc search --refresh database schema                 # update index first, then 
 
 By default, `ccc search` scopes results to your current working directory (relative to the project root). Use `--path` to override.
 
+## Docker
+
+A Docker image is available for teams who want a reproducible, dependency-free
+setup — no Python, `uv`, or system dependencies required on the host.
+
+The recommended approach is a **persistent container**: start it once, and use
+`docker exec` to run CLI commands or connect MCP sessions to it. The daemon
+inside stays warm across sessions, so the embedding model is loaded only once.
+
+### Step 1 — Start the container
+
+```bash
+docker run -d --name cocoindex-code \
+  --volume "$(pwd):/workspace" \
+  --volume cocoindex-db:/db \
+  --volume cocoindex-model-cache:/root/.cache \
+  ghcr.io/cocoindex-io/cocoindex-code:latest
+```
+
+- `/workspace` — mount your project root here
+- `cocoindex-db` — index databases live inside the container (fast native I/O, no cross-OS volume issues)
+- `cocoindex-model-cache` — persists the embedding model across image upgrades
+
+### Step 2 — Index your codebase
+
+```bash
+docker exec -it cocoindex-code ccc index
+```
+
+### Step 3 — Connect your coding agent
+
+<details>
+<summary>Claude Code</summary>
+
+```bash
+claude mcp add cocoindex-code -- docker exec -i cocoindex-code ccc mcp
+```
+
+Or via `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "cocoindex-code": {
+      "type": "stdio",
+      "command": "docker",
+      "args": ["exec", "-i", "cocoindex-code", "ccc", "mcp"]
+    }
+  }
+}
+```
+</details>
+
+<details>
+<summary>Codex</summary>
+
+```bash
+codex mcp add cocoindex-code -- docker exec -i cocoindex-code ccc mcp
+```
+</details>
+
+### CLI usage inside the container
+
+All `ccc` commands work via `docker exec`:
+
+```bash
+docker exec -it cocoindex-code ccc index
+docker exec -it cocoindex-code ccc search "authentication logic"
+docker exec -it cocoindex-code ccc status
+```
+
+Or set an alias on your host so it feels native:
+
+```bash
+alias ccc='docker exec -it cocoindex-code ccc'
+```
+
+### Configuration via environment variables
+
+Pass configuration to `docker run` with `-e`:
+
+```bash
+# Extra extensions (e.g. Typesafe Config, SBT build files)
+-e COCOINDEX_CODE_EXTRA_EXTENSIONS="conf,sbt"
+
+# Exclude build artefacts (Scala/SBT example)
+-e COCOINDEX_CODE_EXCLUDE_PATTERNS='["**/target/**","**/.bloop/**","**/.metals/**"]'
+
+# Swap in a code-optimised embedding model
+-e COCOINDEX_CODE_EMBEDDING_MODEL=voyage/voyage-code-3
+-e VOYAGE_API_KEY=your-key
+```
+
+### Build the image locally
+
+```bash
+docker build -t cocoindex-code:local -f docker/Dockerfile .
+```
+
 ## Features
 - **Semantic Code Search**: Find relevant code using natural language queries when grep doesn't work well, and save tokens immediately.
 - **Ultra Performant**: ⚡ Built on top of ultra performant [Rust indexing engine](https://github.com/cocoindex-io/cocoindex). Only re-indexes changed files for fast updates.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,61 @@
+# ─── Stage 1: install dependencies ───────────────────────────────────────────
+# Use slim (glibc-based) — cocoindex ships pre-built Rust wheels that need glibc.
+# Alpine / musl-libc would require building from source.
+FROM python:3.12-slim AS builder
+
+# Install uv via pip — avoids a ghcr.io pull during build
+RUN pip install --quiet uv
+
+WORKDIR /build
+
+RUN uv pip install --system --prerelease=allow \
+    "cocoindex>=1.0.0a33" \
+    "cocoindex-code" \
+    "sentence-transformers>=3.3.1"
+
+# ─── Stage 2: pre-bake the default embedding model ────────────────────────────
+# Bakes sentence-transformers/all-MiniLM-L6-v2 into the image so cold container
+# starts don't trigger a ~90 MB download. Skip this stage (--target builder) if
+# you always supply COCOINDEX_CODE_EMBEDDING_MODEL pointing at an external model.
+FROM builder AS model_cache
+
+RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2'); print('Model cached.')"
+
+# ─── Stage 3: runtime ─────────────────────────────────────────────────────────
+FROM python:3.12-slim AS runtime
+
+# Copy installed packages and cached model from previous stages
+COPY --from=model_cache /usr/local/lib/python3.12 /usr/local/lib/python3.12
+COPY --from=model_cache /usr/local/bin/cocoindex-code /usr/local/bin/cocoindex-code
+COPY --from=model_cache /usr/local/bin/ccc /usr/local/bin/ccc
+COPY --from=model_cache /root/.cache /root/.cache
+
+# The codebase is mounted at runtime — nothing project-specific lives here.
+WORKDIR /workspace
+
+# ── Runtime defaults (all overridable via -e / --env) ─────────────────────────
+
+# Map index databases into the container's native filesystem so SQLite avoids
+# the slow/unreliable cross-OS volume layer (especially on macOS / Windows).
+# Format: /source=/target  — databases for projects under /workspace go to /db.
+ENV COCOINDEX_CODE_DB_PATH_MAPPING=/workspace=/db
+
+# Additional extensions: add project-specific extras at runtime, e.g.:
+#   -e COCOINDEX_CODE_EXTRA_EXTENSIONS="conf,sbt"
+# See README for ext:lang syntax to map extensions to existing parsers.
+
+# Exclude patterns: override at runtime for your build system, e.g.:
+#   -e COCOINDEX_CODE_EXCLUDE_PATTERNS='["**/target/**","**/node_modules/**"]'
+
+# Embedding model: defaults to local SentenceTransformers (no API key needed).
+# Override for a code-optimised model, e.g.:
+#   -e COCOINDEX_CODE_EMBEDDING_MODEL=voyage/voyage-code-3
+#   -e VOYAGE_API_KEY=your-key
+
+# ── Persistent daemon entrypoint ──────────────────────────────────────────────
+# Initializes user settings on first start, then runs the daemon in the
+# foreground so the container stays alive.
+# Use `docker exec` to invoke the CLI or start an MCP session — see README.
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Initialize user settings on first run, then hand off to the daemon.
+set -e
+
+# `ccc init` creates ~/.cocoindex_code/global_settings.yml if it doesn't exist.
+# It reads COCOINDEX_CODE_EMBEDDING_MODEL and other env vars at this point.
+ccc init -f 2>/dev/null || true
+
+exec ccc run-daemon


### PR DESCRIPTION
# Add Docker support

## What this PR adds

- `docker/Dockerfile` — multi-stage build that produces a self-contained image
- `.github/workflows/docker-publish.yml` — publishes to `ghcr.io/cocoindex-io/cocoindex-code` on every release tag
- README section — Docker usage alongside the existing `uvx` / `claude mcp add` instructions

## Motivation

Some teams can't or don't want to install Python, `uv`, or manage system
dependencies on developer machines. Docker gives them:

- **Reproducibility** — identical environment across macOS, Linux, Windows (WSL2)
- **Isolation** — no Python version conflicts with other tools
- **Zero host deps** — only Docker required

## Design decisions

### Multi-stage build

Three stages keep the final image lean and cache-friendly:

1. **`builder`** — installs cocoindex-code and sentence-transformers via `uv`
2. **`model_cache`** — pre-bakes `all-MiniLM-L6-v2` into the image so cold
   starts don't trigger a ~90 MB download
3. **`runtime`** — copies packages + model from previous stages into a fresh
   `python:3.12-slim` base

### `python:3.12-slim`, not Alpine

cocoindex ships pre-built Rust wheels linked against glibc. Alpine uses musl-libc
and would require building from source.

### `ENTRYPOINT ["cocoindex-code", "serve"]`

`serve` is the MCP stdio subcommand. This keeps the container invocation clean
(`docker run --rm -i ... image`) with no extra arguments needed. Users who want
the one-shot indexer can override with `--entrypoint cocoindex-code ... index`.

### All config via environment variables

No project-specific defaults are baked into the image. `COCOINDEX_CODE_ROOT_PATH`
defaults to `/workspace` (the conventional mount point), everything else is
left to the user's `docker run -e` flags or `.mcp.json` config.

### Named volume for model cache

The default model is baked in, but users who override `COCOINDEX_CODE_EMBEDDING_MODEL`
with an external provider benefit from a named volume so the model is only
downloaded once across rebuilds:
```
docker volume create cocoindex-model-cache
```

## First-time setup note

After the workflow runs for the first time, the `ghcr.io/cocoindex-io/cocoindex-code`
package will be created automatically but will be **private** by default.
A maintainer needs to set it to public once:

> GitHub → org page → Packages → cocoindex-code → Package settings → Change visibility → Public

After that, `docker pull ghcr.io/cocoindex-io/cocoindex-code:latest` works for
everyone without authentication.

## Testing

Tested locally against a Scala/SBT codebase:

1. `docker build -t cocoindex-code:local -f docker/Dockerfile .` — builds cleanly
2. MCP stdio handshake (`initialize` → valid JSON-RPC `result`) ✅
3. `tools/list` returns `search` tool ✅
4. `.cocoindex_code/` index directory created in mounted workspace ✅
5. Wired into Claude Code via `.mcp.json` — semantic search returns results ✅