### PR TITLE
chore: auto-generate _version.py via hatch-vcs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,5 +41,8 @@ htmlcov/
 .pytest_cache/
 .mypy_cache/
 
+# Generated version file
+src/cocoindex_code/_version.py
+
 # CocoIndex
 .cocoindex_code/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,10 @@ Issues = "https://github.com/cocoindex-io/cocoindex-code/issues"
 
 [tool.hatch.version]
 source = "vcs"
+fallback-version = "999.0.0"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/cocoindex_code/_version.py"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/cocoindex_code"]

--- a/src/cocoindex_code/_version.py
+++ b/src/cocoindex_code/_version.py
@@ -1,3 +1,0 @@
-# This file will be rewritten by the release workflow.
-# DO NOT ADD ANYTHING ELSE TO THIS FILE.
-__version__ = "999.0.0"


### PR DESCRIPTION
## Summary
- Configure hatch-vcs build hook to auto-generate `_version.py` from git tags during build
- Remove the hardcoded placeholder `_version.py` and add it to `.gitignore`
- Add `fallback-version = "999.0.0"` for dev environments without git tags

## Test plan
- [x] Verified `uv run python -c "from cocoindex_code._version import __version__; print(__version__)"` works and produces correct dev version
- [x] Pre-commit hooks pass (pytest, ruff, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)