### PR TITLE
fix: close all projects on daemon shutdown

### DIFF
--- a/src/cocoindex_code/daemon.py
+++ b/src/cocoindex_code/daemon.py
@@ -256,6 +256,17 @@ class ProjectRegistry:
             gc.collect()
         return was_loaded
 
+    def close_all(self) -> None:
+        """Close all loaded projects and release resources."""
+        import gc
+
+        for project in self._projects.values():
+            project.close()
+        self._projects.clear()
+        self._index_locks.clear()
+        self._indexing.clear()
+        gc.collect()
+
     def list_projects(self) -> list[DaemonProjectInfo]:
         """List all loaded projects with their indexing state."""
         return [
@@ -519,3 +530,4 @@ async def _async_daemon_main(embedder: Embedder) -> None:
         accept_thread.join(timeout=2)
         if tasks:
             await asyncio.gather(*tasks, return_exceptions=True)
+        registry.close_all()


### PR DESCRIPTION
## Summary
- When the daemon receives a stop request (or signal), explicitly close all loaded `Project` objects in the `ProjectRegistry` before process exit
- This ensures Rust-side resources (CocoIndex Environment/App) are properly freed, preventing shutdown hangs

## Test plan
- [x] `uv run mypy .` passes
- [x] `uv run pytest tests/` — all 91 tests pass
- [ ] Manual: start daemon, load a project, stop daemon, verify clean shutdown without hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)