### PR TITLE
chore: bump cocoindex to 1.0.0a38

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     "mcp>=1.0.0",
-    "cocoindex[litellm]==1.0.0a37",
+    "cocoindex[litellm]==1.0.0a38",
     "sentence-transformers>=2.2.0",
     "sqlite-vec>=0.1.0",
     "pydantic>=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -339,7 +339,7 @@ wheels = [
 
 [[package]]
 name = "cocoindex"
-version = "1.0.0a37"
+version = "1.0.0a38"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -350,17 +350,17 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/6a/a587db56f79a416c5c3b912e4471cdbaa25e502ad91768659ac9794c9c04/cocoindex-1.0.0a37.tar.gz", hash = "sha256:056c11e2b65024489f3a18823fb3d7f8387e8054ea1005daed33923b1f7763ad", size = 291712, upload-time = "2026-03-21T03:58:27.535Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/65/91c7d103f2867d191c880d2517a947f455f1e9889c872136383c60e673d9/cocoindex-1.0.0a38.tar.gz", hash = "sha256:3bf165b74479ed42093b8bce491e50b6b6cec2f47770aeba9a1af0fc142ed0b9", size = 291772, upload-time = "2026-03-24T21:52:43.7Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/b8/b1f20eae25baf97d9c8e72509da3501f4e0f54c570e25cf4df80c7e8e02a/cocoindex-1.0.0a37-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:dd7e9203ae65d164cca7ddbdd38bf9383c1a4c36b0b51062a7c64dc88618892a", size = 6286096, upload-time = "2026-03-21T03:58:25.793Z" },
-    { url = "https://files.pythonhosted.org/packages/26/1c/aa8493092ddca037b453c1bd89e5757e4c81f852042d79d94224b84606c2/cocoindex-1.0.0a37-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:adf8ad986fcedd25374c27db032fef4d3f1e882bbc74ebbb99b9e317835f8856", size = 6393786, upload-time = "2026-03-21T03:58:21.115Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/65/66f8fd01239bcc281835fbba267d0fd8e79da1a121ea1fed7092d2c4dfc3/cocoindex-1.0.0a37-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2f2d996feceb73e12ba820e887b795fcc287fb94be995d6a4f3aca3021d1451a", size = 6187236, upload-time = "2026-03-21T03:58:11.961Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/6d/e14c46d1e92475604064e9db8401c61a536fa09132efa4d0cb4ecb7ef186/cocoindex-1.0.0a37-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:174714f87ecec69e73cf5893970299803603636ea9c6a43d74682bc5e8dd015b", size = 6381807, upload-time = "2026-03-21T03:58:16.558Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/9f/2cd85e3ccc7d4582f4e4835a088fc4f9834e32eecc5c2c819fb863edb44d/cocoindex-1.0.0a37-cp311-abi3-win_amd64.whl", hash = "sha256:f0ee064dbaa38f5713a9fec947d0ba4121aa81ea666fe1f426b91e1663f402e9", size = 6579261, upload-time = "2026-03-21T03:58:29.18Z" },
-    { url = "https://files.pythonhosted.org/packages/56/37/a6742f0b396d0b392e924cb993bfe484bba589622a0e5b75d0a2413dce40/cocoindex-1.0.0a37-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae7beb4731ed3fe3562cc63e9359403645d368bd6557e9022bf8d07f184801fb", size = 6395435, upload-time = "2026-03-21T03:58:23.63Z" },
-    { url = "https://files.pythonhosted.org/packages/42/38/377d679b9719b775d7669c1c08b299996c4c4913ba801e10486994f761fe/cocoindex-1.0.0a37-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:9052cfcbf8dcd2542f4c592b5fd93a2abf23f21e13ac73762d22bd68fea9f533", size = 6185159, upload-time = "2026-03-21T03:58:14.396Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/52/6f874067a0491bf15b37ccda8739370586ef2ffeb600acf5196f5659efe0/cocoindex-1.0.0a37-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:e8515651d51be4c3f64579a3efae74250363a39f805593b4a10acbe35e36bcfb", size = 6378670, upload-time = "2026-03-21T03:58:18.809Z" },
-    { url = "https://files.pythonhosted.org/packages/48/ef/8e0246c9ecb020e9533bfcc6847218c4b3636c5e8a8d01ee84dde4b264eb/cocoindex-1.0.0a37-cp314-cp314t-win_amd64.whl", hash = "sha256:80a4d688727dbc5fdccf2d4ac64e81e6348b69a76bd9148799861e0527809388", size = 6569520, upload-time = "2026-03-21T03:58:31.132Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/42/163e326e456876a4b1c20376e9a95f8500466dbc486ddc61300eec7b1e2f/cocoindex-1.0.0a38-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c0df90066bdc332bfc73eef6ff3ba6b728c988dd91f3144192bbeefc04918159", size = 6287187, upload-time = "2026-03-24T21:52:42.03Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/de/5d2c67eb06cb3bca8d90811910ac688d2b4abb1b1a6da3705cb53232906c/cocoindex-1.0.0a38-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:051637c6828deec43d51c5674aed9d56279295d1f55ac240b50d73c27623af06", size = 6394425, upload-time = "2026-03-24T21:52:37.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/d6/a78de964374afda8e3d84fb80b1a035ff91ba8951db97e768397e758c991/cocoindex-1.0.0a38-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:25fe6d3c3367606d609f1789fc0861bceea2282a5ed87b9cc541722fab1d510f", size = 6186306, upload-time = "2026-03-24T21:52:29.178Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/30/874f83ad99aaf89bd984ed788ff94d87a8dcefe9bcfaab416f418fc527e7/cocoindex-1.0.0a38-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:5dc275f341f18e47962bbc6ce605231ab812cbab79c5ba3788dd91c6f1b84f16", size = 6378985, upload-time = "2026-03-24T21:52:33.753Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/5b/9659e44ac909c9b9aafb05fd41eab01f146876728f26c3ab8f47fa34553b/cocoindex-1.0.0a38-cp311-abi3-win_amd64.whl", hash = "sha256:702e363f71b6291b8412c3123a7fbbec5c66b8dad18aa83c80e7e4afe386fa6b", size = 6573390, upload-time = "2026-03-24T21:52:45.191Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e4/3475f489f2a3dc99c51c3f4abcdbe130522f005401502f4b26bf8fb619f3/cocoindex-1.0.0a38-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a7dca0a59035299a9c627dde365c4e23fc3c95c865bd40956e723016c5dafe50", size = 6394677, upload-time = "2026-03-24T21:52:40.19Z" },
+    { url = "https://files.pythonhosted.org/packages/87/c1/6002b01a60ca174ec76a780902422e2b461853d86facd7a4346c9498ae2e/cocoindex-1.0.0a38-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:828f4cd8c89103823e3d19d3035acd92e2818c6c7faed823f07b342b3d235855", size = 6185651, upload-time = "2026-03-24T21:52:31.559Z" },
+    { url = "https://files.pythonhosted.org/packages/37/59/2dbda51447f4f42dcaf3b57f338cc4ceef9e2782cd06f5283c2535e49186/cocoindex-1.0.0a38-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:94071078db8b57048f2bbd5be85db3cd1bc12d762100b5a5ab20077ca17c1fe7", size = 6379951, upload-time = "2026-03-24T21:52:35.644Z" },
+    { url = "https://files.pythonhosted.org/packages/90/28/f9ce38d0ea55b083bb45330613f92b9c164fcea68ea2edb55b84348edfcb/cocoindex-1.0.0a38-cp314-cp314t-win_amd64.whl", hash = "sha256:5ad7421b5f3f36220db299d7d0905a0f19fe6d2974a3702735988e2ffeb5a4f0", size = 6561879, upload-time = "2026-03-24T21:52:47.087Z" },
 ]
 
 [package.optional-dependencies]
@@ -408,7 +408,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cocoindex", extras = ["litellm"], specifier = "==1.0.0a37" },
+    { name = "cocoindex", extras = ["litellm"], specifier = "==1.0.0a38" },
     { name = "einops", specifier = ">=0.8.2" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "msgspec", specifier = ">=0.19.0" },


### PR DESCRIPTION
#120 

## Summary
- Upgrade cocoindex dependency from 1.0.0a37 to 1.0.0a38

## Test plan
CI