### PR TITLE
Add a rate limiter for litellm

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ embedding:
   provider: sentence-transformers                    # or "litellm"
   model: sentence-transformers/all-MiniLM-L6-v2
   device: mps                                        # optional: cpu, cuda, mps (auto-detected if omitted)
+  min_interval_ms: 300                               # optional: pace LiteLLM embedding requests to reduce 429s; defaults to 5 for LiteLLM
 
 envs:                                                # extra environment variables for the daemon
   OPENAI_API_KEY: your-key                           # only needed if not already in your shell environment
@@ -397,6 +398,7 @@ Set `OLLAMA_API_BASE` in `envs:` if your Ollama server is not at `http://localho
 ```yaml
 embedding:
   model: text-embedding-3-small
+  min_interval_ms: 300                               # optional: override the 5ms LiteLLM default
 envs:
   OPENAI_API_KEY: your-api-key
 ```

--- a/skills/ccc/references/settings.md
+++ b/skills/ccc/references/settings.md
@@ -11,6 +11,7 @@ embedding:
   provider: sentence-transformers   # or "litellm" (default when provider is omitted)
   model: sentence-transformers/all-MiniLM-L6-v2
   device: mps                       # optional: cpu, cuda, mps (auto-detected if omitted)
+  min_interval_ms: 300              # optional: pace LiteLLM embedding requests to reduce 429s; defaults to 5 for LiteLLM
 
 envs:                               # extra environment variables for the daemon
   OPENAI_API_KEY: your-key          # only needed if not already in the shell environment
@@ -23,6 +24,7 @@ envs:                               # extra environment variables for the daemon
 | `embedding.provider` | `sentence-transformers` for local models, `litellm` (or omit) for cloud/remote models |
 | `embedding.model` | Model identifier — format depends on provider (see examples below) |
 | `embedding.device` | Optional. `cpu`, `cuda`, or `mps`. Auto-detected if omitted. Only relevant for `sentence-transformers`. |
+| `embedding.min_interval_ms` | Optional. Minimum delay between LiteLLM embedding requests in milliseconds. Defaults to `5` for LiteLLM and is ignored by `sentence-transformers`. Set explicitly to override the default. |
 | `envs` | Key-value map of environment variables injected into the daemon. Use for API keys not already in the shell environment. |
 
 ### Embedding Model Examples
@@ -53,6 +55,7 @@ embedding:
 ```yaml
 embedding:
   model: text-embedding-3-small
+  min_interval_ms: 300
 envs:
   OPENAI_API_KEY: your-api-key
 ```

--- a/src/cocoindex_code/litellm_embedder.py
+++ b/src/cocoindex_code/litellm_embedder.py
@@ -1,0 +1,126 @@
+"""LiteLLM embedder with optional request pacing and rate-limit retries."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import time
+from typing import Any
+
+import cocoindex as coco
+import numpy as np
+from cocoindex.ops.litellm import LiteLLMEmbedder, litellm
+from numpy.typing import NDArray
+
+logger = logging.getLogger(__name__)
+
+_RATE_LIMIT_DELAY_RE = re.compile(r"Please try again in ([0-9.]+)(ms|s)", re.IGNORECASE)
+_MAX_RATE_LIMIT_RETRIES = 6
+
+
+def _get_rate_limit_delay(exc: Exception, attempt: int) -> float | None:
+    message = str(exc)
+    if "rate limit" not in message.lower():
+        return None
+
+    match = _RATE_LIMIT_DELAY_RE.search(message)
+    if match is not None:
+        value = float(match.group(1))
+        unit = match.group(2).lower()
+        delay = value / 1000.0 if unit == "ms" else value
+    else:
+        delay = min(0.5 * (2**attempt), 10.0)
+
+    return min(delay + 0.1, 10.0)
+
+
+class PacedLiteLLMEmbedder(LiteLLMEmbedder):
+    """LiteLLM embedder that serializes requests and paces them when configured."""
+
+    def __init__(self, model: str, *, min_interval_ms: int | None = None, **kwargs: Any) -> None:
+        super().__init__(model, **kwargs)
+        self._min_request_interval_seconds = max(0.0, float(min_interval_ms or 0) / 1000.0)
+        self._request_lock: asyncio.Lock | None = None
+        self._next_request_at: float = 0.0
+
+    def _get_request_lock(self) -> asyncio.Lock:
+        if self._request_lock is None:
+            self._request_lock = asyncio.Lock()
+        return self._request_lock
+
+    async def _aembedding_with_rate_limit_retries(
+        self, *, model: str, input: list[str], **kwargs: Any
+    ) -> Any:
+        last_exc: Exception | None = None
+
+        for attempt in range(_MAX_RATE_LIMIT_RETRIES):
+            try:
+                return await litellm.aembedding(model=model, input=input, **kwargs)
+            except Exception as exc:  # noqa: BLE001
+                delay = _get_rate_limit_delay(exc, attempt)
+                last_exc = exc
+                if delay is None or attempt == _MAX_RATE_LIMIT_RETRIES - 1:
+                    raise
+
+                logger.warning(
+                    "Embedding rate limited for model %s, retrying in %.3fs (attempt %d/%d)",
+                    model,
+                    delay,
+                    attempt + 1,
+                    _MAX_RATE_LIMIT_RETRIES,
+                )
+                await asyncio.sleep(delay)
+
+        assert last_exc is not None
+        raise last_exc
+
+    async def run_embedding_request(self, *, input: list[str], **kwargs: Any) -> Any:
+        lock = self._get_request_lock()
+        async with lock:
+            now = time.monotonic()
+            if self._next_request_at > now:
+                await asyncio.sleep(self._next_request_at - now)
+
+            response = await self._aembedding_with_rate_limit_retries(
+                model=self._model,
+                input=input,
+                **kwargs,
+            )
+
+            now = time.monotonic()
+            if self._min_request_interval_seconds > 0:
+                self._next_request_at = now + self._min_request_interval_seconds
+            else:
+                self._next_request_at = now
+
+            return response
+
+    async def _get_dim(self) -> int:
+        if self._dim is not None:
+            return self._dim
+        async with self._get_lock():
+            if self._dim is not None:
+                return self._dim
+            response = await self.run_embedding_request(input=["hello"], **self._kwargs)
+            embedding = response.data[0]["embedding"]
+            self._dim = len(embedding)
+            return self._dim
+
+    @coco.fn.as_async(
+        batching=True,
+        max_batch_size=64,
+        memo=True,
+        version=1,
+        logic_tracking="self",
+    )
+    async def embed(
+        self,
+        texts: list[str],
+        input_type: str | None = None,
+    ) -> list[NDArray[np.float32]]:
+        kwargs = dict(self._kwargs)
+        if input_type is not None:
+            kwargs["input_type"] = input_type
+        response = await self.run_embedding_request(input=texts, **kwargs)
+        return [np.array(item["embedding"], dtype=np.float32) for item in response.data]

--- a/src/cocoindex_code/settings.py
+++ b/src/cocoindex_code/settings.py
@@ -92,6 +92,7 @@ class EmbeddingSettings:
     model: str
     provider: str = "litellm"
     device: str | None = None
+    min_interval_ms: int | None = None
 
 
 @dataclass
@@ -351,6 +352,8 @@ def _user_settings_to_dict(settings: UserSettings) -> dict[str, Any]:
     }
     if settings.embedding.device is not None:
         emb["device"] = settings.embedding.device
+    if settings.embedding.min_interval_ms is not None:
+        emb["min_interval_ms"] = settings.embedding.min_interval_ms
     d["embedding"] = emb
     if settings.envs:
         d["envs"] = dict(settings.envs)
@@ -367,6 +370,8 @@ def _user_settings_from_dict(d: dict[str, Any]) -> UserSettings:
         emb_kwargs["provider"] = emb_dict["provider"]
     if "device" in emb_dict:
         emb_kwargs["device"] = emb_dict["device"]
+    if "min_interval_ms" in emb_dict:
+        emb_kwargs["min_interval_ms"] = emb_dict["min_interval_ms"]
     embedding = EmbeddingSettings(**emb_kwargs)
     envs = d.get("envs", {})
     return UserSettings(embedding=embedding, envs=envs)

--- a/src/cocoindex_code/shared.py
+++ b/src/cocoindex_code/shared.py
@@ -21,6 +21,7 @@ from .settings import EmbeddingSettings
 logger = logging.getLogger(__name__)
 
 SBERT_PREFIX = "sbert/"
+DEFAULT_LITELLM_MIN_INTERVAL_MS = 5
 
 # Models that define a "query" prompt for asymmetric retrieval.
 _QUERY_PROMPT_MODELS = {"nomic-ai/nomic-embed-code", "nomic-ai/CodeRankEmbed"}
@@ -63,11 +64,23 @@ def create_embedder(settings: EmbeddingSettings) -> Embedder:
         )
         logger.info("Embedding model: %s | device: %s", settings.model, settings.device)
     else:
-        from cocoindex.ops.litellm import LiteLLMEmbedder
+        from .litellm_embedder import PacedLiteLLMEmbedder
 
-        instance = LiteLLMEmbedder(settings.model)
+        min_interval_ms = (
+            settings.min_interval_ms
+            if settings.min_interval_ms is not None
+            else DEFAULT_LITELLM_MIN_INTERVAL_MS
+        )
+        instance = PacedLiteLLMEmbedder(
+            settings.model,
+            min_interval_ms=min_interval_ms,
+        )
         query_prompt_name = None
-        logger.info("Embedding model (LiteLLM): %s", settings.model)
+        logger.info(
+            "Embedding model (LiteLLM): %s | min_interval_ms: %s",
+            settings.model,
+            min_interval_ms,
+        )
 
     embedder = instance
     return instance

--- a/tests/test_litellm_embedder.py
+++ b/tests/test_litellm_embedder.py
@@ -1,0 +1,72 @@
+"""Unit tests for the paced LiteLLM embedder."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from cocoindex_code.litellm_embedder import PacedLiteLLMEmbedder
+
+
+@pytest.mark.asyncio
+async def test_run_embedding_request_retries_rate_limit_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleep_calls: list[float] = []
+    attempts = 0
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    async def fake_aembedding(*, model: str, input: list[str], **kwargs: Any) -> Any:
+        nonlocal attempts
+        attempts += 1
+        assert model == "text-embedding-3-small"
+        assert input == ["hello"]
+        assert kwargs == {}
+        if attempts == 1:
+            raise Exception("Rate limit exceeded. Please try again in 250ms")
+        return SimpleNamespace(data=[{"embedding": [1.0, 2.0]}])
+
+    monkeypatch.setattr("cocoindex_code.litellm_embedder.asyncio.sleep", fake_sleep)
+    monkeypatch.setattr("cocoindex_code.litellm_embedder.litellm.aembedding", fake_aembedding)
+
+    embedder = PacedLiteLLMEmbedder("text-embedding-3-small")
+    response = await embedder.run_embedding_request(input=["hello"])
+
+    assert attempts == 2
+    assert len(sleep_calls) == 1
+    assert sleep_calls[0] == pytest.approx(0.35)
+    assert response.data == [{"embedding": [1.0, 2.0]}]
+
+
+@pytest.mark.asyncio
+async def test_run_embedding_request_applies_min_interval_between_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleep_calls: list[float] = []
+    inputs_seen: list[list[str]] = []
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    async def fake_aembedding(*, model: str, input: list[str], **kwargs: Any) -> Any:
+        assert model == "text-embedding-3-small"
+        assert kwargs == {}
+        inputs_seen.append(input)
+        return SimpleNamespace(data=[{"embedding": [1.0, 2.0]}])
+
+    monkeypatch.setattr("cocoindex_code.litellm_embedder.asyncio.sleep", fake_sleep)
+    monkeypatch.setattr("cocoindex_code.litellm_embedder.litellm.aembedding", fake_aembedding)
+    monkeypatch.setattr("cocoindex_code.litellm_embedder.time.monotonic", lambda: 10.0)
+
+    embedder = PacedLiteLLMEmbedder("text-embedding-3-small", min_interval_ms=300)
+    embedder._next_request_at = 10.3
+
+    await embedder.run_embedding_request(input=["second"])
+
+    assert inputs_seen == [["second"]]
+    assert len(sleep_calls) == 1
+    assert sleep_calls[0] == pytest.approx(0.3)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -49,6 +49,7 @@ def test_default_user_settings() -> None:
     assert s.embedding.provider == "sentence-transformers"
     assert "all-MiniLM-L6-v2" in s.embedding.model
     assert s.embedding.device is None
+    assert s.embedding.min_interval_ms is None
     assert s.envs == {}
 
 
@@ -66,6 +67,7 @@ def test_save_and_load_user_settings(tmp_path: Path) -> None:
             provider="litellm",
             model="gemini/text-embedding-004",
             device="cpu",
+            min_interval_ms=300,
         ),
         envs={"GEMINI_API_KEY": "test-key"},
     )
@@ -74,6 +76,7 @@ def test_save_and_load_user_settings(tmp_path: Path) -> None:
     assert loaded.embedding.provider == settings.embedding.provider
     assert loaded.embedding.model == settings.embedding.model
     assert loaded.embedding.device == settings.embedding.device
+    assert loaded.embedding.min_interval_ms == settings.embedding.min_interval_ms
     assert loaded.envs == settings.envs
 
 
@@ -123,6 +126,7 @@ def test_from_dict_missing_provider_defaults_to_litellm() -> None:
     settings = _user_settings_from_dict({"embedding": {"model": "some/model"}})
     assert settings.embedding.provider == "litellm"
     assert settings.embedding.model == "some/model"
+    assert settings.embedding.min_interval_ms is None
 
 
 @pytest.mark.usefixtures("_patch_user_dir")
@@ -186,6 +190,7 @@ def test_user_settings_litellm_round_trip() -> None:
         embedding=EmbeddingSettings(
             provider="litellm",
             model="gemini/text-embedding-004",
+            min_interval_ms=250,
         ),
         envs={"GEMINI_API_KEY": "test"},
     )
@@ -193,7 +198,21 @@ def test_user_settings_litellm_round_trip() -> None:
     loaded = load_user_settings()
     assert loaded.embedding.provider == "litellm"
     assert loaded.embedding.model == "gemini/text-embedding-004"
+    assert loaded.embedding.min_interval_ms == 250
     assert loaded.envs == {"GEMINI_API_KEY": "test"}
+
+
+@pytest.mark.usefixtures("_patch_user_dir")
+def test_load_user_settings_with_min_interval_ms(tmp_path: Path) -> None:
+    path = tmp_path / ".cocoindex_code" / "global_settings.yml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "embedding:\n  provider: litellm\n  model: text-embedding-3-small\n  min_interval_ms: 300\n"
+    )
+    loaded = load_user_settings()
+    assert loaded.embedding.provider == "litellm"
+    assert loaded.embedding.model == "text-embedding-3-small"
+    assert loaded.embedding.min_interval_ms == 300
 
 
 def test_project_settings_with_language_overrides(tmp_path: Path) -> None:

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -1,0 +1,30 @@
+"""Tests for embedder creation helpers."""
+
+from __future__ import annotations
+
+from cocoindex_code.litellm_embedder import PacedLiteLLMEmbedder
+from cocoindex_code.settings import EmbeddingSettings
+from cocoindex_code.shared import create_embedder
+
+
+def test_create_embedder_uses_default_litellm_pacing() -> None:
+    embedder = create_embedder(
+        EmbeddingSettings(
+            provider="litellm",
+            model="text-embedding-3-small",
+        )
+    )
+    assert isinstance(embedder, PacedLiteLLMEmbedder)
+    assert embedder._min_request_interval_seconds == 0.005
+
+
+def test_create_embedder_uses_paced_litellm_embedder() -> None:
+    embedder = create_embedder(
+        EmbeddingSettings(
+            provider="litellm",
+            model="text-embedding-3-small",
+            min_interval_ms=300,
+        )
+    )
+    assert isinstance(embedder, PacedLiteLLMEmbedder)
+    assert embedder._min_request_interval_seconds == 0.3


### PR DESCRIPTION
## Summary

- Adds `PacedLiteLLMEmbedder` to serialize LiteLLM embedding requests, apply configurable minimum request spacing, and retry rate-limited calls with bounded backoff.
- Extends user embedding settings with `min_interval_ms` and persists that field through settings serialization and deserialization.
- Wires LiteLLM embedder creation to use a default `5ms` pacing interval when the setting is omitted, and documents the new configuration in the user-facing markdown references.
- Adds direct unit coverage for the new LiteLLM retry and pacing paths using mocked `litellm.aembedding` calls.

## Validation

- `uv run pytest tests/test_litellm_embedder.py -v` passed with `2 passed in 1.60s`.
- `uv run pytest tests/ -v` passed with `108 passed in 159.00s`.
- `uv run pre-commit run --all-files` passed.
