### PR TITLE
chore: bump cocoindex to 1.0.0a43

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 
 dependencies = [
     "mcp>=1.0.0",
-    "cocoindex[litellm]==1.0.0a38",
+    "cocoindex[litellm]==1.0.0a43",
     "sentence-transformers>=2.2.0",
     "sqlite-vec>=0.1.0",
     "pydantic>=2.0.0",

--- a/src/cocoindex_code/indexer.py
+++ b/src/cocoindex_code/indexer.py
@@ -224,5 +224,6 @@ async def indexer_main() -> None:
         path_matcher=matcher,
     )
 
-    with coco.component_subpath(coco.Symbol("process_file")):
-        await coco.mount_each(process_file, files.items(), table)
+    await coco.mount_each(
+        coco.component_subpath(coco.Symbol("process_file")), process_file, files.items(), table
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -339,10 +339,11 @@ wheels = [
 
 [[package]]
 name = "cocoindex"
-version = "1.0.0a38"
+version = "1.0.0a43"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
+    { name = "msgspec" },
     { name = "numpy" },
     { name = "psutil" },
     { name = "python-dotenv" },
@@ -350,17 +351,17 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/84/65/91c7d103f2867d191c880d2517a947f455f1e9889c872136383c60e673d9/cocoindex-1.0.0a38.tar.gz", hash = "sha256:3bf165b74479ed42093b8bce491e50b6b6cec2f47770aeba9a1af0fc142ed0b9", size = 291772, upload-time = "2026-03-24T21:52:43.7Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/ae/89036ba4b5890c76de18b118195f08f1000b77b428be243cdfb26f48cb62/cocoindex-1.0.0a43.tar.gz", hash = "sha256:6569c91b6e01951d5d3419942ba5d0ef952ba89006f021ab25a28306d3400e55", size = 329738, upload-time = "2026-04-09T19:36:17.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6d/42/163e326e456876a4b1c20376e9a95f8500466dbc486ddc61300eec7b1e2f/cocoindex-1.0.0a38-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c0df90066bdc332bfc73eef6ff3ba6b728c988dd91f3144192bbeefc04918159", size = 6287187, upload-time = "2026-03-24T21:52:42.03Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/de/5d2c67eb06cb3bca8d90811910ac688d2b4abb1b1a6da3705cb53232906c/cocoindex-1.0.0a38-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:051637c6828deec43d51c5674aed9d56279295d1f55ac240b50d73c27623af06", size = 6394425, upload-time = "2026-03-24T21:52:37.933Z" },
-    { url = "https://files.pythonhosted.org/packages/95/d6/a78de964374afda8e3d84fb80b1a035ff91ba8951db97e768397e758c991/cocoindex-1.0.0a38-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:25fe6d3c3367606d609f1789fc0861bceea2282a5ed87b9cc541722fab1d510f", size = 6186306, upload-time = "2026-03-24T21:52:29.178Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/30/874f83ad99aaf89bd984ed788ff94d87a8dcefe9bcfaab416f418fc527e7/cocoindex-1.0.0a38-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:5dc275f341f18e47962bbc6ce605231ab812cbab79c5ba3788dd91c6f1b84f16", size = 6378985, upload-time = "2026-03-24T21:52:33.753Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/5b/9659e44ac909c9b9aafb05fd41eab01f146876728f26c3ab8f47fa34553b/cocoindex-1.0.0a38-cp311-abi3-win_amd64.whl", hash = "sha256:702e363f71b6291b8412c3123a7fbbec5c66b8dad18aa83c80e7e4afe386fa6b", size = 6573390, upload-time = "2026-03-24T21:52:45.191Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/e4/3475f489f2a3dc99c51c3f4abcdbe130522f005401502f4b26bf8fb619f3/cocoindex-1.0.0a38-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a7dca0a59035299a9c627dde365c4e23fc3c95c865bd40956e723016c5dafe50", size = 6394677, upload-time = "2026-03-24T21:52:40.19Z" },
-    { url = "https://files.pythonhosted.org/packages/87/c1/6002b01a60ca174ec76a780902422e2b461853d86facd7a4346c9498ae2e/cocoindex-1.0.0a38-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:828f4cd8c89103823e3d19d3035acd92e2818c6c7faed823f07b342b3d235855", size = 6185651, upload-time = "2026-03-24T21:52:31.559Z" },
-    { url = "https://files.pythonhosted.org/packages/37/59/2dbda51447f4f42dcaf3b57f338cc4ceef9e2782cd06f5283c2535e49186/cocoindex-1.0.0a38-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:94071078db8b57048f2bbd5be85db3cd1bc12d762100b5a5ab20077ca17c1fe7", size = 6379951, upload-time = "2026-03-24T21:52:35.644Z" },
-    { url = "https://files.pythonhosted.org/packages/90/28/f9ce38d0ea55b083bb45330613f92b9c164fcea68ea2edb55b84348edfcb/cocoindex-1.0.0a38-cp314-cp314t-win_amd64.whl", hash = "sha256:5ad7421b5f3f36220db299d7d0905a0f19fe6d2974a3702735988e2ffeb5a4f0", size = 6561879, upload-time = "2026-03-24T21:52:47.087Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8f/14a2c53b4b84eb2f928261e88e0fb0a80d387c950a1f1604ddcecf30d428/cocoindex-1.0.0a43-cp311-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a9b91f3da9b8b42ee5dd6939d804e7bbf41b6ec8d91125bee2b0f00b61123e9c", size = 6484139, upload-time = "2026-04-09T19:36:15.966Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/7f/3008551d2c45b5e47c7c5ff02b784fe442cd2a14e9aeec27017a80a76842/cocoindex-1.0.0a43-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:0919ff6e788720973c999388e9d2ff718cc6d16e9daa478c36a151789cfd2705", size = 6589417, upload-time = "2026-04-09T19:36:12.786Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7c/eda090462a6fc7354a777a082d5097103e453cc01bb21c18b5ead6e6a159/cocoindex-1.0.0a43-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:4c2a4335a904743a7371585fc8df0b1b1d8a9a4953c46cf63ced57e573928e0f", size = 6398791, upload-time = "2026-04-09T19:36:05.941Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/b5c3d95ef194cb6816d7c660ca7e163453f233fc2e67e54699a09beab466/cocoindex-1.0.0a43-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:ba810b8ae47dd772ebd89fc3bdc1cc57a94630f38cc0d2dae0c1fb7966cef708", size = 6595432, upload-time = "2026-04-09T19:36:09.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/0c/05fcefdc56510c2cbecaf83efe9213d0a0d80720d60aea1895a70a02a6a0/cocoindex-1.0.0a43-cp311-abi3-win_amd64.whl", hash = "sha256:868a96f19e2ba629fac73a6131a682865df2f0f15f64eedb18f3f0bd403b1f4a", size = 6817206, upload-time = "2026-04-09T19:36:18.539Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b0/6bf1fbf30126d50f772388746965ea5a00b4476b70d48571c11fa909c1b0/cocoindex-1.0.0a43-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:65541e78681716079f99b3212654280212a7ca972401dfbd6315b76fd314ddb6", size = 6586540, upload-time = "2026-04-09T19:36:14.227Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/f7/ba86b961885a8ebdc1dfaf3aea73309708e606aaf8016bd55d52bbdbfdea/cocoindex-1.0.0a43-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:e4169191eebc33db66c35f280d1d970c1b8badb335f82a0a0c0951f6a464913a", size = 6390430, upload-time = "2026-04-09T19:36:07.924Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/78/05c08b2253b5f0be9082a8bf6d868326c0b96b6025f05b40ffa4e92276dd/cocoindex-1.0.0a43-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:bb0c157e5ce8ac36b2708e63ac46ea6eb0dba79a1621d930411b9fe1c2570515", size = 6589096, upload-time = "2026-04-09T19:36:11.27Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8a/ab014c6a522173b6fecd6d0f4913bfbbdc369e3b35cc5bd2c81dd78ee946/cocoindex-1.0.0a43-cp314-cp314t-win_amd64.whl", hash = "sha256:4217047a9195508ac2c0af70ec46c8a2943ce60c95c4b449d0e1c06aec74979c", size = 6806702, upload-time = "2026-04-09T19:36:20.342Z" },
 ]
 
 [package.optional-dependencies]
@@ -408,7 +409,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "cocoindex", extras = ["litellm"], specifier = "==1.0.0a38" },
+    { name = "cocoindex", extras = ["litellm"], specifier = "==1.0.0a43" },
     { name = "einops", specifier = ">=0.8.2" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "msgspec", specifier = ">=0.19.0" },


### PR DESCRIPTION
## Summary
- Bump `cocoindex` from `1.0.0a38` to `1.0.0a43`
- Update `mount_each` call in indexer to match new API (subpath as positional arg instead of context manager)

## Test plan
CI
