### PR TITLE
feat: make sentence-transformers optional; interactive `ccc init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,18 @@ A lightweight, effective **(AST-based)** semantic code search tool for your code
 
 Using [pipx](https://pipx.pypa.io/stable/installation/):
 ```bash
-pipx install cocoindex-code       # first install
-pipx upgrade cocoindex-code       # upgrade
+pipx install 'cocoindex-code[default]'       # batteries included (local embeddings)
+pipx upgrade cocoindex-code                  # upgrade
 ```
 
 Using [uv](https://docs.astral.sh/uv/getting-started/installation/):
 ```bash
-uv tool install --upgrade cocoindex-code --prerelease explicit --with "cocoindex>=1.0.0a24"
+uv tool install --upgrade 'cocoindex-code[default]' --prerelease explicit --with "cocoindex>=1.0.0a24"
 ```
 
-The default embedding model runs locally ([sentence-transformers/all-MiniLM-L6-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2)) — no API key required, completely free.
+Two install styles:
+- `cocoindex-code[default]` — batteries-included. Pulls in `sentence-transformers` so local embeddings (no API key required) work out of the box. The `ccc init` interactive prompt defaults to [Snowflake/snowflake-arctic-embed-xs](https://huggingface.co/Snowflake/snowflake-arctic-embed-xs).
+- `cocoindex-code` — slim. LiteLLM-only; requires a cloud embedding provider and API key. Use when you don't want the local-embedding deps (~1 GB of torch + transformers).
 
 Next, set up your [coding agent integration](#coding-agent-integration) — or jump to [Manual CLI Usage](#manual-cli-usage) if you prefer direct control.
 
@@ -275,8 +277,7 @@ Pass configuration to `docker run` with `-e`:
 # Exclude build artefacts (Scala/SBT example)
 -e COCOINDEX_CODE_EXCLUDE_PATTERNS='["**/target/**","**/.bloop/**","**/.metals/**"]'
 
-# Swap in a code-optimised embedding model
--e COCOINDEX_CODE_EMBEDDING_MODEL=voyage/voyage-code-3
+# Set an API key
 -e VOYAGE_API_KEY=your-key
 ```
 
@@ -291,7 +292,7 @@ docker build -t cocoindex-code:local -f docker/Dockerfile .
 - **Ultra Performant**: ⚡ Built on top of ultra performant [Rust indexing engine](https://github.com/cocoindex-io/cocoindex). Only re-indexes changed files for fast updates.
 - **Multi-Language Support**: Python, JavaScript/TypeScript, Rust, Go, Java, C/C++, C#, SQL, Shell, and more.
 - **Embedded**: Portable and just works, no database setup required!
-- **Flexible Embeddings**: Local SentenceTransformers by default (free!) or 100+ cloud providers via LiteLLM.
+- **Flexible Embeddings**: Local SentenceTransformers via the `[default]` extra (free, no API key!) or 100+ cloud providers via LiteLLM.
 
 ## Configuration
 
@@ -304,7 +305,7 @@ Shared across all projects. Controls the embedding model and environment variabl
 ```yaml
 embedding:
   provider: sentence-transformers                    # or "litellm"
-  model: sentence-transformers/all-MiniLM-L6-v2
+  model: Snowflake/snowflake-arctic-embed-xs
   device: mps                                        # optional: cpu, cuda, mps (auto-detected if omitted)
   min_interval_ms: 300                               # optional: pace LiteLLM embedding requests to reduce 429s; defaults to 5 for LiteLLM
 
@@ -376,7 +377,7 @@ See [`src/cocoindex_code/chunking.py`](./src/cocoindex_code/chunking.py) for the
 
 ## Embedding Models
 
-By default, a local SentenceTransformers model ([sentence-transformers/all-MiniLM-L6-v2](https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2)) is used — no API key required. To use a different model, edit `~/.cocoindex_code/global_settings.yml`.
+With the `[default]` extra installed, `ccc init` defaults to a local SentenceTransformers model ([Snowflake/snowflake-arctic-embed-xs](https://huggingface.co/Snowflake/snowflake-arctic-embed-xs)) — no API key required. To use a different model, edit `~/.cocoindex_code/global_settings.yml`.
 
 > The `envs` entries below are only needed if the key isn't already in your shell environment — the daemon inherits your environment automatically.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,16 +10,15 @@ WORKDIR /build
 
 RUN uv pip install --system --prerelease=allow \
     "cocoindex>=1.0.0a33" \
-    "cocoindex-code" \
-    "sentence-transformers>=3.3.1"
+    "cocoindex-code[default]"
 
 # ─── Stage 2: pre-bake the default embedding model ────────────────────────────
-# Bakes sentence-transformers/all-MiniLM-L6-v2 into the image so cold container
-# starts don't trigger a ~90 MB download. Skip this stage (--target builder) if
-# you always supply COCOINDEX_CODE_EMBEDDING_MODEL pointing at an external model.
+# Bakes Snowflake/snowflake-arctic-embed-xs into the image so cold container
+# starts don't trigger a download. Skip this stage (--target builder) if
+# you always supply a global_settings.yml pointing at a non-local model.
 FROM builder AS model_cache
 
-RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('sentence-transformers/all-MiniLM-L6-v2'); print('Model cached.')"
+RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('Snowflake/snowflake-arctic-embed-xs'); print('Model cached.')"
 
 # ─── Stage 3: runtime ─────────────────────────────────────────────────────────
 FROM python:3.12-slim AS runtime
@@ -47,10 +46,11 @@ ENV COCOINDEX_CODE_DB_PATH_MAPPING=/workspace=/db
 # Exclude patterns: override at runtime for your build system, e.g.:
 #   -e COCOINDEX_CODE_EXCLUDE_PATTERNS='["**/target/**","**/node_modules/**"]'
 
-# Embedding model: defaults to local SentenceTransformers (no API key needed).
-# Override for a code-optimised model, e.g.:
-#   -e COCOINDEX_CODE_EMBEDDING_MODEL=voyage/voyage-code-3
-#   -e VOYAGE_API_KEY=your-key
+# Embedding model: defaults to local sentence-transformers
+# (Snowflake/snowflake-arctic-embed-xs, pre-baked above).
+# To use a different model, pre-mount a global_settings.yml into
+# ~/.cocoindex_code/ before the container starts, e.g.
+#   -v /path/to/global_settings.yml:/root/.cocoindex_code/global_settings.yml
 
 # ── Persistent daemon entrypoint ──────────────────────────────────────────────
 # Initializes user settings on first start, then runs the daemon in the

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,8 +2,9 @@
 # Initialize user settings on first run, then hand off to the daemon.
 set -e
 
-# `ccc init` creates ~/.cocoindex_code/global_settings.yml if it doesn't exist.
-# It reads COCOINDEX_CODE_EMBEDDING_MODEL and other env vars at this point.
+# `ccc init` creates ~/.cocoindex_code/global_settings.yml with the default
+# embedding model if the file doesn't already exist. Pre-mount a custom
+# global_settings.yml to override (see Dockerfile comments).
 ccc init -f 2>/dev/null || true
 
 exec ccc run-daemon

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
 dependencies = [
     "mcp>=1.0.0",
     "cocoindex[litellm]==1.0.0a43",
-    "sentence-transformers>=2.2.0",
     "sqlite-vec>=0.1.0",
     "pydantic>=2.0.0",
     "numpy>=1.24.0",
@@ -33,9 +32,16 @@ dependencies = [
     "msgspec>=0.19.0",
     "pathspec>=0.12.1",
     "pyyaml>=6.0",
+    "questionary>=2.0.0",
 ]
 
 [project.optional-dependencies]
+embeddings-local = [
+    "cocoindex[sentence-transformers]==1.0.0a43",
+]
+default = [
+    "cocoindex[sentence-transformers]==1.0.0a43",
+]
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
@@ -43,6 +49,7 @@ dev = [
     "ruff>=0.1.0",
     "mypy>=1.0.0",
     "prek>=0.1.0",
+    "cocoindex[sentence-transformers]==1.0.0a43",
 ]
 
 [project.scripts]
@@ -76,6 +83,7 @@ dev = [
     "mypy>=1.0.0",
     "prek>=0.1.0",
     "types-pyyaml>=6.0.12.20250915",
+    "cocoindex[sentence-transformers]==1.0.0a43",
 ]
 
 [tool.uv]

--- a/skills/ccc/references/settings.md
+++ b/skills/ccc/references/settings.md
@@ -9,7 +9,7 @@ Shared across all projects. Controls the embedding model and extra environment v
 ```yaml
 embedding:
   provider: sentence-transformers   # or "litellm" (default when provider is omitted)
-  model: sentence-transformers/all-MiniLM-L6-v2
+  model: Snowflake/snowflake-arctic-embed-xs
   device: mps                       # optional: cpu, cuda, mps (auto-detected if omitted)
   min_interval_ms: 300              # optional: pace LiteLLM embedding requests to reduce 429s; defaults to 5 for LiteLLM
 
@@ -34,7 +34,7 @@ envs:                               # extra environment variables for the daemon
 ```yaml
 embedding:
   provider: sentence-transformers
-  model: sentence-transformers/all-MiniLM-L6-v2    # default, lightweight
+  model: Snowflake/snowflake-arctic-embed-xs        # default, lightweight
 ```
 
 ```yaml

--- a/src/cocoindex_code/cli.py
+++ b/src/cocoindex_code/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import sys
 from collections.abc import Callable
 from pathlib import Path
 from typing import TypeVar
@@ -12,15 +13,16 @@ import typer as _typer
 from .client import DaemonStartError
 from .protocol import DoctorCheckResult, IndexingProgress, ProjectStatusResponse, SearchResponse
 from .settings import (
+    DEFAULT_ST_MODEL,
+    EmbeddingSettings,
     cocoindex_db_path,
     default_project_settings,
-    default_user_settings,
     find_parent_with_marker,
     find_project_root,
     project_settings_path,
     resolve_db_dir,
+    save_initial_user_settings,
     save_project_settings,
-    save_user_settings,
     target_sqlite_db_path,
     user_settings_path,
 )
@@ -282,19 +284,173 @@ def remove_from_gitignore(project_root: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
+_LITELLM_MODELS_URL = "https://docs.litellm.ai/docs/embedding/supported_embedding"
+
+
+def _resolve_embedding_choice(
+    litellm_model_flag: str | None,
+    st_installed: bool,
+    tty: bool,
+) -> EmbeddingSettings:
+    """Resolve the embedding settings per the init control-flow diagram."""
+    if litellm_model_flag is not None:
+        return EmbeddingSettings(provider="litellm", model=litellm_model_flag)
+
+    if not tty:
+        if st_installed:
+            return EmbeddingSettings(provider="sentence-transformers", model=DEFAULT_ST_MODEL)
+        _typer.echo(
+            "Error: sentence-transformers is not installed and stdin is not a TTY.\n"
+            "Either install the extra (`pip install cocoindex-code[embeddings-local]`)\n"
+            "or pass `--litellm-model MODEL` to select a LiteLLM model.",
+            err=True,
+        )
+        raise _typer.Exit(code=1)
+
+    # Interactive
+    import questionary
+
+    if st_installed:
+        provider = questionary.select(
+            "Embedding provider",
+            choices=[
+                questionary.Choice(
+                    title="sentence-transformers (local, free)",
+                    value="sentence-transformers",
+                ),
+                questionary.Choice(
+                    title="litellm (cloud, 100+ providers)",
+                    value="litellm",
+                ),
+            ],
+        ).ask()
+    else:
+        _typer.echo(
+            "sentence-transformers is not installed — only `litellm` is available.\n"
+            "To enable local embeddings, install `cocoindex-code[embeddings-local]`."
+        )
+        provider = "litellm"
+
+    if provider is None:  # user cancelled (Ctrl-C / Esc)
+        raise _typer.Exit(code=1)
+
+    if provider == "sentence-transformers":
+        model = questionary.text("Model name", default=DEFAULT_ST_MODEL).ask()
+    elif provider == "litellm":
+        _typer.echo(f"See supported LiteLLM embedding models: {_LITELLM_MODELS_URL}")
+        model = questionary.text("Model name").ask()
+    else:
+        _typer.echo(f"Error: unknown provider {provider!r}", err=True)
+        raise _typer.Exit(code=1)
+
+    if not model:  # None (cancelled) or empty string
+        raise _typer.Exit(code=1)
+
+    return EmbeddingSettings(provider=provider, model=model.strip())
+
+
+def _ok_fail_tag(ok: bool) -> str:
+    """Return a colored `[OK]` or `[FAIL]` tag string."""
+    import click as _click
+
+    if ok:
+        return _click.style("[OK]", fg="green", bold=True)
+    return _click.style("[FAIL]", fg="red", bold=True)
+
+
+def _run_init_model_check(settings_path: Path) -> None:
+    """Ask the daemon to test the embedding model; print results and a hint on failure.
+
+    Drives the check via `DoctorRequest(project_root=None)`. The daemon loads
+    the model once and stays running, so the user's next `ccc index` starts
+    warm. Both DaemonStartError and generic exceptions are rendered as a
+    synthetic failed DoctorCheckResult — uniform failure-output shape.
+    """
+    from rich.console import Console as _Console
+    from rich.live import Live as _Live
+    from rich.spinner import Spinner as _Spinner
+
+    from . import client as _client
+
+    err_console = _Console(stderr=True)
+    results: list[DoctorCheckResult] = []
+    try:
+        with _Live(
+            _Spinner("dots", "Testing embedding model..."),
+            console=err_console,
+            transient=True,
+        ):
+            results = _client.doctor(project_root=None)
+    except Exception as e:
+        results = [
+            DoctorCheckResult(
+                name="Model Check",
+                ok=False,
+                details=[],
+                errors=[f"{type(e).__name__}: {e}"],
+            )
+        ]
+
+    failed = False
+    for r in results:
+        if r.name == "done":
+            continue
+        _print_doctor_result(r)
+        if not r.ok:
+            failed = True
+
+    if failed:
+        _typer.echo(
+            f"You can edit {settings_path} to change the model or add API keys\n"
+            "under `envs:`. Then run `ccc doctor` to verify.",
+            err=True,
+        )
+
+
+def _setup_user_settings_interactive(litellm_model_flag: str | None) -> None:
+    """Interactive global-settings setup — only runs when settings are missing."""
+    from .shared import is_sentence_transformers_installed
+
+    embedding = _resolve_embedding_choice(
+        litellm_model_flag=litellm_model_flag,
+        st_installed=is_sentence_transformers_installed(),
+        tty=sys.stdin.isatty(),
+    )
+
+    path = save_initial_user_settings(embedding)
+    _typer.echo()
+    _typer.echo(f"Created user settings: {path}")
+
+    _typer.echo()
+    _typer.echo(f"Testing embedding model: {embedding.provider} / {embedding.model}")
+    _run_init_model_check(path)
+    _typer.echo()
+
+
 @app.command()
 def init(
+    litellm_model: str | None = _typer.Option(
+        None,
+        "--litellm-model",
+        help="Use the given LiteLLM model and skip provider/model prompts.",
+    ),
     force: bool = _typer.Option(False, "-f", "--force", help="Skip parent directory warning"),
 ) -> None:
     """Initialize a project for cocoindex-code."""
     cwd = Path.cwd().resolve()
     settings_file = project_settings_path(cwd)
 
-    # Always ensure user settings exist
     user_path = user_settings_path()
-    if not user_path.is_file():
-        save_user_settings(default_user_settings())
-        _typer.echo(f"Created user settings: {user_path}")
+    if user_path.is_file():
+        if litellm_model is not None:
+            _typer.echo(
+                f"Error: global settings already exist at {user_path}.\n"
+                "Edit that file or remove it before passing `--litellm-model`.",
+                err=True,
+            )
+            raise _typer.Exit(code=1)
+    else:
+        _setup_user_settings_interactive(litellm_model)
 
     # Check if already initialized
     if settings_file.is_file():
@@ -489,10 +645,7 @@ def _print_doctor_result(result: DoctorCheckResult) -> None:
 
     if result.name == "done":
         return
-    if result.ok:
-        tag = _click.style("[OK]", fg="green", bold=True)
-    else:
-        tag = _click.style("[FAIL]", fg="red", bold=True)
+    tag = _ok_fail_tag(result.ok)
     _typer.echo(f"\n  {tag} {result.name}")
     for line in result.details:
         _typer.echo(f"    {line}")

--- a/src/cocoindex_code/daemon.py
+++ b/src/cocoindex_code/daemon.py
@@ -61,7 +61,7 @@ from .settings import (
     load_user_settings,
     target_sqlite_db_path,
 )
-from .shared import Embedder, create_embedder
+from .shared import Embedder, check_embedding, create_embedder
 
 logger = logging.getLogger(__name__)
 
@@ -262,22 +262,20 @@ async def _handle_doctor(
 
 async def _check_model(embedder: Embedder) -> DoctorCheckResult:
     """Test the embedding model by embedding a short string."""
-    try:
-        vec = await embedder.embed("hello world")
-        dim = len(vec)
+    result = await check_embedding(embedder)
+    if result.error is None:
         return DoctorCheckResult(
             name="Model Check",
             ok=True,
-            details=[f"Embedding dimension: {dim}"],
+            details=[f"Embedding dimension: {result.dim}"],
             errors=[],
         )
-    except Exception as e:
-        return DoctorCheckResult(
-            name="Model Check",
-            ok=False,
-            details=[],
-            errors=[str(e)],
-        )
+    return DoctorCheckResult(
+        name="Model Check",
+        ok=False,
+        details=[],
+        errors=[result.error],
+    )
 
 
 async def _check_file_walk(project_root_str: str) -> DoctorCheckResult:

--- a/src/cocoindex_code/settings.py
+++ b/src/cocoindex_code/settings.py
@@ -126,11 +126,14 @@ class ProjectSettings:
 # ---------------------------------------------------------------------------
 
 
+DEFAULT_ST_MODEL = "Snowflake/snowflake-arctic-embed-xs"
+
+
 def default_user_settings() -> UserSettings:
     return UserSettings(
         embedding=EmbeddingSettings(
             provider="sentence-transformers",
-            model="sentence-transformers/all-MiniLM-L6-v2",
+            model=DEFAULT_ST_MODEL,
         )
     )
 
@@ -344,17 +347,20 @@ def load_gitignore_spec(project_root: Path) -> GitIgnoreSpec | None:
 # ---------------------------------------------------------------------------
 
 
-def _user_settings_to_dict(settings: UserSettings) -> dict[str, Any]:
-    d: dict[str, Any] = {}
-    emb: dict[str, Any] = {
-        "provider": settings.embedding.provider,
-        "model": settings.embedding.model,
+def _embedding_settings_to_dict(embedding: EmbeddingSettings) -> dict[str, Any]:
+    d: dict[str, Any] = {
+        "provider": embedding.provider,
+        "model": embedding.model,
     }
-    if settings.embedding.device is not None:
-        emb["device"] = settings.embedding.device
-    if settings.embedding.min_interval_ms is not None:
-        emb["min_interval_ms"] = settings.embedding.min_interval_ms
-    d["embedding"] = emb
+    if embedding.device is not None:
+        d["device"] = embedding.device
+    if embedding.min_interval_ms is not None:
+        d["min_interval_ms"] = embedding.min_interval_ms
+    return d
+
+
+def _user_settings_to_dict(settings: UserSettings) -> dict[str, Any]:
+    d: dict[str, Any] = {"embedding": _embedding_settings_to_dict(settings.embedding)}
     if settings.envs:
         d["envs"] = dict(settings.envs)
     return d
@@ -433,6 +439,46 @@ def save_user_settings(settings: UserSettings) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
     with open(path, "w") as f:
         _yaml.safe_dump(_user_settings_to_dict(settings), f, default_flow_style=False)
+    return path
+
+
+_INITIAL_HEADER = (
+    "# CocoIndex Code — global settings.\n"
+    "# After editing this file, run `ccc doctor` to verify your configuration.\n"
+    "\n"
+)
+
+_INITIAL_ENVS_COMMENT = (
+    "\n"
+    "# Environment variables to inject into the daemon running in the background.\n"
+    "# Uncomment and fill in keys for the LiteLLM providers you plan to use.\n"
+    "#\n"
+    "# envs:\n"
+    "#   OPENAI_API_KEY: ...\n"
+    "#   GEMINI_API_KEY: ...\n"
+    "#   ANTHROPIC_API_KEY: ...\n"
+    "#   VOYAGE_API_KEY: ...\n"
+)
+
+
+def save_initial_user_settings(embedding: EmbeddingSettings) -> Path:
+    """Write the initial global_settings.yml with comment hints and env examples.
+
+    Only used by `ccc init` on first-time setup. Emits only the `embedding:`
+    block from the input; the `envs:` section is a commented-out template.
+    Subsequent programmatic writes use `save_user_settings` and do not
+    preserve comments.
+    """
+    emb_block = _yaml.safe_dump(
+        {"embedding": _embedding_settings_to_dict(embedding)},
+        default_flow_style=False,
+        sort_keys=False,
+    )
+    content = _INITIAL_HEADER + emb_block + _INITIAL_ENVS_COMMENT
+
+    path = user_settings_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
     return path
 
 

--- a/src/cocoindex_code/shared.py
+++ b/src/cocoindex_code/shared.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+import importlib.util
 import logging
 import pathlib
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Annotated, Union
+from typing import TYPE_CHECKING, Annotated, NamedTuple, Union
 
 import cocoindex as coco
 import numpy as np
@@ -39,6 +40,41 @@ embedder: Embedder | None = None
 
 # Query prompt name — set alongside embedder by create_embedder().
 query_prompt_name: str | None = None
+
+
+def is_sentence_transformers_installed() -> bool:
+    """Return True if the `sentence_transformers` package can be imported.
+
+    Uses `find_spec` rather than `import` to avoid triggering the slow,
+    torch-loading import as a side effect of the check.
+    """
+    return importlib.util.find_spec("sentence_transformers") is not None
+
+
+class EmbeddingCheckResult(NamedTuple):
+    """Outcome of a single embed-test call. See `check_embedding`.
+
+    Exactly one of ``dim`` / ``error`` is set: ``error is None`` means success.
+    """
+
+    dim: int | None
+    error: str | None
+
+
+async def check_embedding(embedder: Embedder) -> EmbeddingCheckResult:
+    """Run a single embed call against *embedder* and report dim or error.
+
+    Never raises. Used by both the daemon's doctor path (`daemon._check_model`)
+    and the CLI's init flow (`cli._test_embedding_model`).
+    """
+    try:
+        vec = await embedder.embed("hello world")
+        return EmbeddingCheckResult(dim=len(vec), error=None)
+    except Exception as e:
+        msg = f"{type(e).__name__}: {e}".splitlines()[0]
+        if len(msg) > 500:
+            msg = msg[:500] + "…"
+        return EmbeddingCheckResult(dim=None, error=msg)
 
 
 def create_embedder(settings: EmbeddingSettings) -> Embedder:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,40 @@
 """Pytest configuration and fixtures."""
 
+from __future__ import annotations
+
 import os
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from cocoindex_code.settings import UserSettings
 
 # === Environment setup BEFORE any cocoindex_code imports ===
 _TEST_DIR = Path(tempfile.mkdtemp(prefix="cocoindex_test_"))
 os.environ["COCOINDEX_CODE_ROOT_PATH"] = str(_TEST_DIR)
+
+
+# Lighter than the production default (Snowflake/snowflake-arctic-embed-xs)
+# so tests keep CI cache costs low while still exercising the full embedder
+# code path.
+TEST_EMBEDDING_MODEL = "sentence-transformers/paraphrase-MiniLM-L3-v2"
+
+
+# NOTE: deliberately NOT prefixed with `test_` — pytest auto-collects any
+# top-level `test_*` function as a test case.
+def make_test_user_settings() -> UserSettings:
+    """Lightweight UserSettings for tests — uses a smaller model than the production default."""
+    from cocoindex_code.settings import EmbeddingSettings, UserSettings
+
+    return UserSettings(
+        embedding=EmbeddingSettings(
+            provider="sentence-transformers",
+            model=TEST_EMBEDDING_MODEL,
+        ),
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -15,6 +15,7 @@ from multiprocessing.connection import Client, Connection
 from pathlib import Path
 
 import pytest
+from conftest import make_test_user_settings
 
 from cocoindex_code._daemon_paths import connection_family
 from cocoindex_code._version import __version__
@@ -36,7 +37,6 @@ from cocoindex_code.protocol import (
 )
 from cocoindex_code.settings import (
     default_project_settings,
-    default_user_settings,
     save_project_settings,
     save_user_settings,
 )
@@ -60,7 +60,9 @@ def daemon_sock() -> Iterator[str]:
     from cocoindex_code.shared import embedder as shared_emb
 
     emb = (
-        shared_emb if shared_emb is not None else create_embedder(default_user_settings().embedding)
+        shared_emb
+        if shared_emb is not None
+        else create_embedder(make_test_user_settings().embedding)
     )
 
     # Use a short path to stay within AF_UNIX limit
@@ -77,7 +79,7 @@ def daemon_sock() -> Iterator[str]:
     _orig_create_embedder = dm.create_embedder
     dm.create_embedder = lambda settings: emb
 
-    save_user_settings(default_user_settings())
+    save_user_settings(make_test_user_settings())
 
     thread = threading.Thread(target=dm.run_daemon, daemon=True)
     thread.start()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import pytest
 from cocoindex.connectors import sqlite as coco_sqlite
+from conftest import make_test_user_settings
 from typer.testing import CliRunner
 
 from cocoindex_code.cli import app
@@ -23,7 +24,10 @@ from cocoindex_code.settings import (
     _reset_db_path_mapping_cache,
     default_project_settings,
     find_parent_with_marker,
+    load_user_settings,
     save_project_settings,
+    save_user_settings,
+    user_settings_path,
 )
 
 runner = CliRunner()
@@ -119,6 +123,11 @@ def e2e_project() -> Iterator[Path]:
     os.environ["COCOINDEX_CODE_DIR"] = str(base_dir)
     old_cwd = os.getcwd()
     os.chdir(project_dir)
+
+    # Pre-write global settings with the lightweight test model so `ccc init`
+    # in these tests skips the new interactive flow and existing assertions
+    # continue to exercise the same indexing behavior as before.
+    save_user_settings(make_test_user_settings())
 
     try:
         yield project_dir
@@ -579,6 +588,252 @@ def test_session_daemon_restart_missing_global_settings() -> None:
     assert result.exit_code != 0, f"Expected failure but got: {result.output}"
     assert "Daemon log:" in result.output
     assert "User settings not found" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Interactive init flow tests
+# ---------------------------------------------------------------------------
+
+
+def _fake_doctor_ok(
+    project_root: str | None = None,
+    on_result: object = None,
+) -> list[object]:
+    """Stand-in for ``client.doctor`` that returns a single OK Model Check."""
+    from cocoindex_code.protocol import DoctorCheckResult
+
+    ok = DoctorCheckResult(
+        name="Model Check",
+        ok=True,
+        details=["Embedding dimension: 384"],
+        errors=[],
+    )
+    done = DoctorCheckResult(name="done", ok=True, details=[], errors=[])
+    return [ok, done]
+
+
+@pytest.fixture()
+def e2e_fresh_env(monkeypatch: pytest.MonkeyPatch) -> Iterator[Path]:
+    """Fresh COCOINDEX_CODE_DIR with NO global settings and NO project settings.
+
+    Distinct from ``e2e_project`` (which pre-writes global settings): tests
+    that exercise the interactive init flow need a genuinely empty state.
+    ``client.doctor`` is monkeypatched so no real daemon starts and no real
+    model is loaded during tests.
+    """
+    base_dir = Path(tempfile.mkdtemp(prefix="ccc_e2e_fresh_"))
+    project_dir = base_dir / "project"
+    project_dir.mkdir()
+    (project_dir / "main.py").write_text(SAMPLE_MAIN_PY)
+    (project_dir / ".git").mkdir()
+
+    old_env = os.environ.get("COCOINDEX_CODE_DIR")
+    os.environ["COCOINDEX_CODE_DIR"] = str(base_dir)
+    old_cwd = os.getcwd()
+    os.chdir(project_dir)
+
+    monkeypatch.setattr("cocoindex_code.client.doctor", _fake_doctor_ok)
+
+    try:
+        yield project_dir
+    finally:
+        os.chdir(old_cwd)
+        stop_daemon()
+        if old_env is None:
+            os.environ.pop("COCOINDEX_CODE_DIR", None)
+        else:
+            os.environ["COCOINDEX_CODE_DIR"] = old_env
+
+
+def test_resolve_embedding_choice_flag_wins() -> None:
+    """--litellm-model flag short-circuits all other logic."""
+    from cocoindex_code.cli import _resolve_embedding_choice
+
+    embedding = _resolve_embedding_choice(
+        litellm_model_flag="openai/text-embedding-3-small",
+        st_installed=True,
+        tty=True,
+    )
+    assert embedding.provider == "litellm"
+    assert embedding.model == "openai/text-embedding-3-small"
+
+
+def test_resolve_embedding_choice_non_tty_defaults_to_snowflake() -> None:
+    """Non-TTY + ST installed → sentence-transformers + Snowflake defaults."""
+    from cocoindex_code.cli import _resolve_embedding_choice
+    from cocoindex_code.settings import DEFAULT_ST_MODEL
+
+    embedding = _resolve_embedding_choice(
+        litellm_model_flag=None,
+        st_installed=True,
+        tty=False,
+    )
+    assert embedding.provider == "sentence-transformers"
+    assert embedding.model == DEFAULT_ST_MODEL
+
+
+def test_resolve_embedding_choice_non_tty_slim_errors() -> None:
+    """Non-TTY + ST NOT installed + no flag → typer.Exit with guidance."""
+    import typer
+
+    from cocoindex_code.cli import _resolve_embedding_choice
+
+    with pytest.raises(typer.Exit) as exc_info:
+        _resolve_embedding_choice(
+            litellm_model_flag=None,
+            st_installed=False,
+            tty=False,
+        )
+    assert exc_info.value.exit_code == 1
+
+
+def test_init_non_tty_with_flag(e2e_fresh_env: Path) -> None:
+    """Non-TTY (CliRunner default) + --litellm-model works without prompts."""
+    result = runner.invoke(
+        app,
+        ["init", "--litellm-model", "openai/text-embedding-3-small"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    loaded = load_user_settings()
+    assert loaded.embedding.provider == "litellm"
+    assert loaded.embedding.model == "openai/text-embedding-3-small"
+
+
+def test_init_non_tty_no_flag_uses_defaults(e2e_fresh_env: Path) -> None:
+    """Non-TTY + ST installed → defaults to sentence-transformers + Snowflake."""
+    result = runner.invoke(app, ["init"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+
+    loaded = load_user_settings()
+    assert loaded.embedding.provider == "sentence-transformers"
+    assert loaded.embedding.model == "Snowflake/snowflake-arctic-embed-xs"
+
+
+def test_init_non_tty_slim_install_no_flag_errors(
+    e2e_fresh_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-TTY + ST NOT installed + no flag → error before writing settings."""
+    monkeypatch.setattr(
+        "cocoindex_code.shared.is_sentence_transformers_installed",
+        lambda: False,
+    )
+    result = runner.invoke(app, ["init"])
+    assert result.exit_code != 0
+    combined = result.output + result.stderr if result.stderr else result.output
+    assert "--litellm-model" in combined
+    assert "embeddings-local" in combined
+    assert not user_settings_path().is_file()
+
+
+def test_init_slim_install_with_flag(e2e_fresh_env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """ST not installed, --litellm-model given → LiteLLM settings written."""
+    monkeypatch.setattr(
+        "cocoindex_code.shared.is_sentence_transformers_installed",
+        lambda: False,
+    )
+    result = runner.invoke(
+        app,
+        ["init", "--litellm-model", "openai/text-embedding-3-small"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+
+    loaded = load_user_settings()
+    assert loaded.embedding.provider == "litellm"
+    assert loaded.embedding.model == "openai/text-embedding-3-small"
+
+
+def test_init_model_test_failure_is_non_fatal(
+    e2e_fresh_env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Model-test failure does NOT abort init; project settings still written."""
+    from cocoindex_code.protocol import DoctorCheckResult
+
+    def _fake_doctor_fail(
+        project_root: str | None = None,
+        on_result: object = None,
+    ) -> list[DoctorCheckResult]:
+        fail = DoctorCheckResult(
+            name="Model Check",
+            ok=False,
+            details=[],
+            errors=["AuthenticationError: missing key"],
+        )
+        done = DoctorCheckResult(name="done", ok=True, details=[], errors=[])
+        return [fail, done]
+
+    monkeypatch.setattr("cocoindex_code.client.doctor", _fake_doctor_fail)
+    result = runner.invoke(
+        app,
+        ["init", "--litellm-model", "openai/text-embedding-3-small"],
+        catch_exceptions=False,
+    )
+    assert result.exit_code == 0, result.output
+    combined = result.output + (result.stderr or "")
+    assert "[FAIL]" in combined
+    assert "AuthenticationError" in combined
+    assert "ccc doctor" in combined
+    assert "envs:" in combined
+
+    # Settings file was written (not rolled back) and project was initialized.
+    assert user_settings_path().is_file()
+    assert (e2e_fresh_env / ".cocoindex_code" / "settings.yml").exists()
+
+
+def test_init_rejects_litellm_model_when_settings_exist(e2e_project: Path) -> None:
+    """With global settings pre-written by e2e_project, --litellm-model is rejected."""
+    result = runner.invoke(app, ["init", "--litellm-model", "openai/foo"])
+    assert result.exit_code != 0
+    combined = result.output + (result.stderr or "")
+    assert "already exist" in combined
+
+
+def test_init_force_does_not_suppress_prompts(e2e_fresh_env: Path) -> None:
+    """`-f` only affects the parent-marker warning, not the interactive-flow gate."""
+    result = runner.invoke(app, ["init", "-f"], catch_exceptions=False)
+    # Non-TTY + ST installed → non-TTY defaults, same as without -f.
+    assert result.exit_code == 0, result.output
+
+    loaded = load_user_settings()
+    assert loaded.embedding.provider == "sentence-transformers"
+    assert loaded.embedding.model == "Snowflake/snowflake-arctic-embed-xs"
+
+
+# ---------------------------------------------------------------------------
+# Doctor model-check failure path
+# ---------------------------------------------------------------------------
+
+
+async def test_daemon_check_model_maps_failure_to_doctor_result() -> None:
+    """daemon._check_model delegates to check_embedding and maps failures correctly."""
+    from cocoindex_code.daemon import _check_model
+
+    class _BoomEmbedder:
+        async def embed(self, text: str) -> object:  # noqa: ARG002
+            raise RuntimeError("boom")
+
+    result = await _check_model(_BoomEmbedder())
+    assert result.name == "Model Check"
+    assert result.ok is False
+    assert result.details == []
+    assert len(result.errors) == 1
+    assert result.errors[0].startswith("RuntimeError:")
+    assert "boom" in result.errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Dockerfile packaging regression guard
+# ---------------------------------------------------------------------------
+
+
+def test_dockerfile_install_line_uses_default_extra() -> None:
+    """Dockerfile should install via `cocoindex-code[default]`, no separate ST pin."""
+    repo_root = Path(__file__).resolve().parent.parent
+    content = (repo_root / "docker" / "Dockerfile").read_text()
+    assert "cocoindex-code[default]" in content
+    assert "sentence-transformers>=" not in content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -14,6 +14,7 @@ from collections.abc import Iterator
 from pathlib import Path
 
 import pytest
+from conftest import make_test_user_settings
 
 from cocoindex_code import client
 from cocoindex_code._version import __version__
@@ -21,7 +22,6 @@ from cocoindex_code.client import start_daemon, stop_daemon
 from cocoindex_code.daemon import daemon_socket_path
 from cocoindex_code.settings import (
     default_project_settings,
-    default_user_settings,
     save_project_settings,
     save_user_settings,
 )
@@ -54,7 +54,7 @@ def e2e_daemon() -> Iterator[tuple[str, Path]]:
     os.environ["COCOINDEX_CODE_DIR"] = str(base_dir)
 
     try:
-        save_user_settings(default_user_settings())
+        save_user_settings(make_test_user_settings())
         save_project_settings(project_dir, default_project_settings())
 
         proc = start_daemon()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -47,7 +47,7 @@ def _patch_user_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
 def test_default_user_settings() -> None:
     s = default_user_settings()
     assert s.embedding.provider == "sentence-transformers"
-    assert "all-MiniLM-L6-v2" in s.embedding.model
+    assert s.embedding.model == "Snowflake/snowflake-arctic-embed-xs"
     assert s.embedding.device is None
     assert s.embedding.min_interval_ms is None
     assert s.envs == {}
@@ -137,7 +137,7 @@ def test_save_default_settings_writes_explicit_embedding() -> None:
     content = user_settings_path().read_text()
     assert "provider:" in content
     assert "model:" in content
-    assert "sentence-transformers" in content
+    assert "Snowflake/snowflake-arctic-embed-xs" in content
 
 
 def test_load_project_settings_missing_file_raises(tmp_path: Path) -> None:
@@ -334,3 +334,48 @@ def test_resolve_chunker_registry_not_callable() -> None:
     # os.path is a module attribute that is a string — not callable.
     with pytest.raises(ValueError, match="not callable"):
         _resolve_chunker_registry([ChunkerMapping(ext="toml", module="os:sep")])
+
+
+@pytest.mark.usefixtures("_patch_user_dir")
+def test_save_initial_user_settings_round_trip() -> None:
+    from cocoindex_code.settings import (
+        save_initial_user_settings,
+        user_settings_path,
+    )
+
+    emb = EmbeddingSettings(
+        provider="sentence-transformers",
+        model="Snowflake/snowflake-arctic-embed-xs",
+    )
+    path = save_initial_user_settings(emb)
+    content = path.read_text()
+
+    # Hint comment and the four commented env-var examples.
+    assert "ccc doctor" in content
+    assert "# envs:" in content
+    for key in ("OPENAI_API_KEY", "GEMINI_API_KEY", "ANTHROPIC_API_KEY", "VOYAGE_API_KEY"):
+        assert f"#   {key}:" in content
+
+    # Must round-trip through the normal loader.
+    loaded = load_user_settings()
+    assert loaded.embedding.provider == "sentence-transformers"
+    assert loaded.embedding.model == "Snowflake/snowflake-arctic-embed-xs"
+
+    # user_settings_path() is the same path returned by save_initial_user_settings.
+    assert path == user_settings_path()
+
+
+@pytest.mark.usefixtures("_patch_user_dir")
+def test_save_initial_user_settings_model_with_colon() -> None:
+    """Regression: LiteLLM model names can contain `:`; must stay parseable."""
+    from cocoindex_code.settings import save_initial_user_settings
+
+    emb = EmbeddingSettings(
+        provider="litellm",
+        model="ollama_chat/llama3:latest",
+    )
+    save_initial_user_settings(emb)
+
+    loaded = load_user_settings()
+    assert loaded.embedding.provider == "litellm"
+    assert loaded.embedding.model == "ollama_chat/llama3:latest"

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
+from typing import Any
+
+import numpy as np
+import pytest
+
 from cocoindex_code.litellm_embedder import PacedLiteLLMEmbedder
 from cocoindex_code.settings import EmbeddingSettings
-from cocoindex_code.shared import create_embedder
+from cocoindex_code.shared import (
+    check_embedding,
+    create_embedder,
+    is_sentence_transformers_installed,
+)
 
 
 def test_create_embedder_uses_default_litellm_pacing() -> None:
@@ -28,3 +37,41 @@ def test_create_embedder_uses_paced_litellm_embedder() -> None:
     )
     assert isinstance(embedder, PacedLiteLLMEmbedder)
     assert embedder._min_request_interval_seconds == 0.3
+
+
+def test_is_sentence_transformers_installed_true_in_dev() -> None:
+    # Dev env pulls in sentence-transformers via the `dev` extras group.
+    assert is_sentence_transformers_installed() is True
+
+
+def test_is_sentence_transformers_installed_false_when_find_spec_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import importlib.util
+
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+    assert is_sentence_transformers_installed() is False
+
+
+class _StubOkEmbedder:
+    async def embed(self, text: str) -> Any:
+        return np.zeros(384, dtype=np.float32)
+
+
+class _StubErrEmbedder:
+    async def embed(self, text: str) -> Any:
+        raise RuntimeError("boom")
+
+
+async def test_check_embedding_ok() -> None:
+    result = await check_embedding(_StubOkEmbedder())
+    assert result.error is None
+    assert result.dim == 384
+
+
+async def test_check_embedding_error() -> None:
+    result = await check_embedding(_StubErrEmbedder())
+    assert result.dim is None
+    assert result.error is not None
+    assert result.error.startswith("RuntimeError:")
+    assert "boom" in result.error

--- a/uv.lock
+++ b/uv.lock
@@ -368,6 +368,9 @@ wheels = [
 litellm = [
     { name = "litellm" },
 ]
+sentence-transformers = [
+    { name = "sentence-transformers" },
+]
 
 [[package]]
 name = "cocoindex-code"
@@ -381,13 +384,17 @@ dependencies = [
     { name = "pathspec" },
     { name = "pydantic" },
     { name = "pyyaml" },
-    { name = "sentence-transformers" },
+    { name = "questionary" },
     { name = "sqlite-vec" },
     { name = "typer" },
 ]
 
 [package.optional-dependencies]
+default = [
+    { name = "cocoindex", extra = ["sentence-transformers"] },
+]
 dev = [
+    { name = "cocoindex", extra = ["sentence-transformers"] },
     { name = "mypy" },
     { name = "prek" },
     { name = "pytest" },
@@ -395,9 +402,13 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+embeddings-local = [
+    { name = "cocoindex", extra = ["sentence-transformers"] },
+]
 
 [package.dev-dependencies]
 dev = [
+    { name = "cocoindex", extra = ["sentence-transformers"] },
     { name = "mypy" },
     { name = "prek" },
     { name = "pytest" },
@@ -410,6 +421,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "cocoindex", extras = ["litellm"], specifier = "==1.0.0a43" },
+    { name = "cocoindex", extras = ["sentence-transformers"], marker = "extra == 'default'", specifier = "==1.0.0a43" },
+    { name = "cocoindex", extras = ["sentence-transformers"], marker = "extra == 'dev'", specifier = "==1.0.0a43" },
+    { name = "cocoindex", extras = ["sentence-transformers"], marker = "extra == 'embeddings-local'", specifier = "==1.0.0a43" },
     { name = "einops", specifier = ">=0.8.2" },
     { name = "mcp", specifier = ">=1.0.0" },
     { name = "msgspec", specifier = ">=0.19.0" },
@@ -422,15 +436,16 @@ requires-dist = [
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "questionary", specifier = ">=2.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
-    { name = "sentence-transformers", specifier = ">=2.2.0" },
     { name = "sqlite-vec", specifier = ">=0.1.0" },
     { name = "typer", specifier = ">=0.9.0" },
 ]
-provides-extras = ["dev"]
+provides-extras = ["default", "dev", "embeddings-local"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "cocoindex", extras = ["sentence-transformers"], specifier = "==1.0.0a43" },
     { name = "mypy", specifier = ">=1.0.0" },
     { name = "prek", specifier = ">=0.1.0" },
     { name = "pytest", specifier = ">=7.0.0" },
@@ -1797,6 +1812,18 @@ wheels = [
 ]
 
 [[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2214,6 +2241,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "questionary"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "prompt-toolkit" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/45/eafb0bba0f9988f6a2520f9ca2df2c82ddfa8d67c95d6625452e97b204a5/questionary-2.1.1.tar.gz", hash = "sha256:3d7e980292bb0107abaa79c68dd3eee3c561b83a0f89ae482860b181c8bd412d", size = 25845, upload-time = "2025-08-28T19:00:20.851Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/26/1062c7ec1b053db9e499b4d2d5bc231743201b74051c973dadeac80a8f43/questionary-2.1.1-py3-none-any.whl", hash = "sha256:a51af13f345f1cdea62347589fbb6df3b290306ab8930713bfae4d475a7d4a59", size = 36753, upload-time = "2025-08-28T19:00:19.56Z" },
 ]
 
 [[package]]
@@ -3155,6 +3194,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/95/615e72cd27b85b61eec764a5ca51bd94d40b5adea5ff47567d9ebc4d275a/watchfiles-1.1.1-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:89eef07eee5e9d1fda06e38822ad167a044153457e6fd997f8a858ab7564a336", size = 396117, upload-time = "2025-10-14T15:06:11.28Z" },
     { url = "https://files.pythonhosted.org/packages/c9/81/e7fe958ce8a7fb5c73cc9fb07f5aeaf755e6aa72498c57d760af760c91f8/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce19e06cbda693e9e7686358af9cd6f5d61312ab8b00488bc36f5aabbaf77e24", size = 450493, upload-time = "2025-10-14T15:06:12.321Z" },
     { url = "https://files.pythonhosted.org/packages/6e/d4/ed38dd3b1767193de971e694aa544356e63353c33a85d948166b5ff58b9e/watchfiles-1.1.1-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3e6f39af2eab0118338902798b5aa6664f46ff66bc0280de76fca67a7f262a49", size = 457546, upload-time = "2025-10-14T15:06:13.372Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes #117 (optional `sentence-transformers`) and #70 (interactive `ccc init`).

- **Packaging** — `sentence-transformers` moves behind new `[embeddings-local]` and `[default]` extras (delegated to `cocoindex[sentence-transformers]` so the pin lives in one place). Bare `pip install cocoindex-code` becomes LiteLLM-only.
- **Interactive `ccc init`** — when global settings don't exist, prompts for provider (sentence-transformers / litellm) and model via a `questionary` TUI. New `--litellm-model MODEL` flag skips prompts and is the non-TTY escape hatch for LiteLLM. The interactive flow is gated on "global settings missing" — subsequent `ccc init` calls in other projects keep the old behavior.
- **Default model** changes from `sentence-transformers/all-MiniLM-L6-v2` to `Snowflake/snowflake-arctic-embed-xs` (lighter, better for code retrieval).
- **Generated `global_settings.yml`** now includes a `ccc doctor` reminder and commented-out env-var examples (`OPENAI_API_KEY`, `GEMINI_API_KEY`, `ANTHROPIC_API_KEY`, `VOYAGE_API_KEY`).
- **Model test runs in the daemon** — init sends a `DoctorRequest` via the existing `_client.doctor` path; the daemon loads the model once and stays running, so the user's next `ccc index` starts warm. Output is wrapped in a rich spinner; HF warnings and "Loading weights" progress stream to `daemon.log` instead of cluttering the init output.
- **Docker** — image now installs `cocoindex-code[default]` and pre-caches the Snowflake model. The `COCOINDEX_CODE_EMBEDDING_MODEL` env var is no longer documented for Docker; users mount a pre-written `global_settings.yml` or pass `--litellm-model`.
- **Shared helper** — extract `check_embedding` + `EmbeddingCheckResult` into `shared.py`. Daemon's `_check_model` delegates to it; error messages in `ccc doctor` output now include the exception type name (strictly more informative).
- **Tests** — switch to the lighter `paraphrase-MiniLM-L3-v2` model via a new `make_test_user_settings()` helper in `conftest.py`, keeping CI cache costs unchanged. New E2E tests cover the init flows (TTY defaults, `--litellm-model`, non-TTY slim install error, failure-is-non-fatal, flag-rejected-when-settings-exist).

## Test plan

- CI (ruff, mypy, pytest — 130 tests including new init-flow coverage).
- Manual smoke test of `ccc init` with a bogus `--litellm-model`: FAIL tag + edit-settings hint + project init still completes. ✓
