### PR TITLE
ci: drop macOS 3.14t matrix cell

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -21,6 +21,14 @@ jobs:
           # pywin32 doesn't have wheels for Python 3.14t (free-threaded) on Windows yet
           - os: windows-latest
             python-version: '3.14t'
+          # tokenizers has no free-threaded wheel; the source-build fallback
+          # fails to link on macOS arm64 since an Apr 2026 runner-image update.
+          # Standard Python 3.14 (non-FT) users are unaffected — they pick up
+          # tokenizers' abi3 wheel. Re-enable once HuggingFace/tokenizers ships
+          # free-threaded wheels (or switch to a newer litellm that drops the
+          # tokenizers dep).
+          - os: macos-latest
+            python-version: '3.14t'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary

Drop `macos-latest` + `3.14t` from the pre-commit matrix — it's been failing consistently on main since Apr 9. Root cause is `tokenizers` (transitive via `litellm`) not shipping free-threaded wheels, combined with macOS arm64's stricter linker rejecting the PyO3 source-build on `3.14t`.

- End users on standard Python 3.14 are **unaffected** — they get `tokenizers`' `cp39-abi3-macosx_11_0_arm64.whl` stable-ABI wheel, no source build.
- Ubuntu + 3.14t stays in the matrix (its source build still works under Linux `ld`).
- Windows + 3.14t was already excluded (no `pywin32` wheel for FT).

Comment in the workflow points at the conditions under which the cell can be re-enabled (upstream tokenizers FT wheels, or litellm dropping the tokenizers dep).

## Test plan

CI — expect the remaining matrix cells (ubuntu-latest 3.11 + 3.14t, macos-latest 3.11, windows-latest 3.11) to stay green; the red `macos-latest 3.14t` cell no longer runs.
