### PR TITLE
docs: update ccc skill install + init guidance

### DIFF
--- a/skills/ccc/references/management.md
+++ b/skills/ccc/references/management.md
@@ -2,11 +2,14 @@
 
 ## Installation
 
-Install CocoIndex Code via pipx:
+Install CocoIndex Code via pipx. Two install styles:
 
 ```bash
-pipx install cocoindex-code
+pipx install 'cocoindex-code[default]'   # batteries included (local embeddings via sentence-transformers)
+pipx install cocoindex-code              # slim (LiteLLM-only; requires a cloud embedding provider + API key)
 ```
+
+The `[default]` extra pulls in `sentence-transformers` so the first-run default (local embeddings, no API key) works out of the box. The slim install is for environments where you don't want the torch/transformers deps and plan to use a LiteLLM-supported cloud provider instead.
 
 To upgrade to the latest version:
 
@@ -24,15 +27,27 @@ Run from the root directory of the project to index:
 ccc init
 ```
 
-This creates:
-- `~/.cocoindex_code/global_settings.yml` (user-level settings, e.g., model configuration) if it does not already exist.
-- `.cocoindex_code/settings.yml` (project-level settings, e.g., include/exclude file patterns).
+**First run (global settings don't exist yet)** — `ccc init` prompts interactively for the embedding provider (sentence-transformers / litellm) and model, then runs a one-off test embed via the daemon to confirm the model works. Accept the defaults for the sentence-transformers path, or pick litellm and enter a model identifier.
+
+**Subsequent runs** (global settings already exist) — prompts are skipped; only project settings and `.gitignore` are set up.
+
+To skip the interactive prompts on the first run (e.g. in a script or container), pass `--litellm-model MODEL`:
+
+```bash
+ccc init --litellm-model openai/text-embedding-3-small
+```
+
+This is also the only way to pick a LiteLLM model when stdin isn't a TTY and you've done a slim install.
+
+`ccc init` creates:
+- `~/.cocoindex_code/global_settings.yml` (user-level, embedding config + env vars).
+- `.cocoindex_code/settings.yml` (project-level, include/exclude patterns).
 
 If `.git` exists in the directory, `.cocoindex_code/` is automatically added to `.gitignore`.
 
 Use `-f` to skip the confirmation prompt if `ccc init` detects a potential parent project root.
 
-After initialization, edit the settings files if needed (see [settings.md](settings.md) for format details), then run `ccc index` to build the initial index.
+After initialization, edit the settings files if needed (see [settings.md](settings.md) for format details), then run `ccc index` to build the initial index. If the model test printed `[FAIL]` during `init`, edit `global_settings.yml` (and optionally add API keys under the commented `envs:` block) and verify with `ccc doctor` before indexing.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Follow-up to #132. The `skills/ccc` docs still described the pre-#132 install and init behavior:

- Install line said `pipx install cocoindex-code` — which after #132 is slim (LiteLLM-only). Agents reading the skill would no longer get the local-embedding default they expect.
- `ccc init` was described as purely non-interactive — no mention of the new prompts, `--litellm-model` flag, or `ccc doctor` pointer on model-test failure.

This PR updates [skills/ccc/references/management.md](skills/ccc/references/management.md) to cover:

- Both install styles: `[default]` (batteries included) vs bare (slim).
- First-run interactive flow + what's skipped on subsequent runs.
- `--litellm-model` flag for non-TTY / scripted use.
- `ccc doctor` as the recovery path if the init model test fails.

## Test plan

Docs-only; CI runs the usual lint/type/tests anyway.
