### PR TITLE
feat: unified Docker workspace mount with supervised daemon

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,31 @@
+# Git + VCS
+.git/
+.gitignore
+
+# Python
+__pycache__/
+*.pyc
+*.pyo
+.mypy_cache/
+.pytest_cache/
+.ruff_cache/
+.venv/
+venv/
+dist/
+build/
+*.egg-info/
+
+# IDE / editor
+.idea/
+.vscode/
+*.swp
+.DS_Store
+
+# Project artifacts
+.cocoindex_code/
+specs/
+tests/e2e_docker_fixtures/  # test fixtures — not needed in image builds
+
+# Docs (the image ships no docs)
+*.md
+!README.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,3 +105,47 @@ jobs:
           gh release upload
           '${{ github.ref_name }}' dist/*
           --repo '${{ github.repository }}'
+
+  publish-docker:
+    name: Build & push Docker image to Docker Hub and GHCR
+    if: github.event_name == 'release'
+    needs:
+      - publish-to-pypi
+    runs-on: ubuntu-latest
+    environment:
+      name: docker-hub
+      url: https://hub.docker.com/r/cocoindex/cocoindex-code
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push to both registries
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: |
+            cocoindex/cocoindex-code:latest
+            cocoindex/cocoindex-code:${{ github.ref_name }}
+            ghcr.io/cocoindex-io/cocoindex-code:latest
+            ghcr.io/cocoindex-io/cocoindex-code:${{ github.ref_name }}

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,7 @@ src/cocoindex_code/_version.py
 
 # CocoIndex Code (ccc)
 /.cocoindex_code/
+
+# Docker E2E fixtures contain a `lib/` dir that the generic Python rule above
+# would ignore — keep it tracked.
+!tests/e2e_docker_fixtures/**

--- a/README.md
+++ b/README.md
@@ -198,33 +198,79 @@ The recommended approach is a **persistent container**: start it once, and use
 `docker exec` to run CLI commands or connect MCP sessions to it. The daemon
 inside stays warm across sessions, so the embedding model is loaded only once.
 
-### Step 1 — Start the container
+### Quick start — `docker compose up -d`
+
+Grab [`docker/docker-compose.yml`](./docker/docker-compose.yml) from this repo and run:
+
+```bash
+# macOS / Windows
+docker compose up -d
+
+# Linux (aligns file ownership on bind-mounted paths with your host user)
+PUID=$(id -u) PGID=$(id -g) docker compose up -d
+```
+
+By default your home directory is mounted into the container (set
+`COCOINDEX_HOST_WORKSPACE` to narrow this to a specific code folder). Index
+data and the embedding model cache persist in a Docker volume across
+restarts. Your global settings file at `$HOME/.cocoindex_code/global_settings.yml`
+is visible and editable on the host; edits take effect on your next `ccc` command.
+
+> **GHCR:** to pull from GitHub Container Registry instead of Docker Hub,
+> change the `image:` line in your copy of `docker-compose.yml` to
+> `ghcr.io/cocoindex-io/cocoindex-code:latest`.
+
+### Or: `docker run`
+
+<details>
+<summary>Docker Desktop (macOS / Windows)</summary>
 
 ```bash
 docker run -d --name cocoindex-code \
-  --volume "$(pwd):/workspace" \
-  --volume cocoindex-db:/db \
-  --volume cocoindex-model-cache:/root/.cache \
-  ghcr.io/cocoindex-io/cocoindex-code:latest
+  --volume "$HOME:/workspace" \
+  --volume cocoindex-data:/var/cocoindex \
+  -e COCOINDEX_CODE_HOST_PATH_MAPPING="/workspace=$HOME" \
+  cocoindex/cocoindex-code:latest
 ```
+</details>
 
-- `/workspace` — mount your project root here
-- `cocoindex-db` — index databases live inside the container (fast native I/O, no cross-OS volume issues)
-- `cocoindex-model-cache` — persists the embedding model across image upgrades
-
-### Step 2 — Index your codebase
+<details>
+<summary>Linux (with <code>PUID</code>/<code>PGID</code>)</summary>
 
 ```bash
-docker exec -it cocoindex-code ccc index
+docker run -d --name cocoindex-code \
+  -e PUID=$(id -u) -e PGID=$(id -g) \
+  --volume "$HOME:/workspace" \
+  --volume cocoindex-data:/var/cocoindex \
+  -e COCOINDEX_CODE_HOST_PATH_MAPPING="/workspace=$HOME" \
+  cocoindex/cocoindex-code:latest
+```
+</details>
+
+### Shell wrapper for `ccc` commands
+
+Paste this into `~/.bashrc` / `~/.zshrc` so `ccc` feels native on the host
+and picks up the right project based on your current directory:
+
+```bash
+ccc() {
+  docker exec -it -e COCOINDEX_CODE_HOST_CWD="$PWD" cocoindex-code ccc "$@"
+}
 ```
 
-### Step 3 — Connect your coding agent
+Now `cd` into any project under your workspace and run `ccc init`, `ccc index`,
+`ccc search ...`, `ccc status`, etc. — it just works.
+
+### Connect your coding agent
 
 <details>
 <summary>Claude Code</summary>
 
+Register MCP from inside the target project so `$PWD` points there:
+
 ```bash
-claude mcp add cocoindex-code -- docker exec -i cocoindex-code ccc mcp
+claude mcp add cocoindex-code -- docker exec -i \
+  -e COCOINDEX_CODE_HOST_CWD="$PWD" cocoindex-code ccc mcp
 ```
 
 Or via `.mcp.json`:
@@ -235,40 +281,50 @@ Or via `.mcp.json`:
     "cocoindex-code": {
       "type": "stdio",
       "command": "docker",
-      "args": ["exec", "-i", "cocoindex-code", "ccc", "mcp"]
+      "args": [
+        "exec",
+        "-i",
+        "-e",
+        "COCOINDEX_CODE_HOST_CWD=${PWD}",
+        "cocoindex-code",
+        "ccc",
+        "mcp"
+      ]
     }
   }
 }
 ```
+
+> Note: use `-i` (not `-it`). The `-t` flag allocates a terminal, which
+> interferes with MCP's JSON messaging over stdin/stdout — only add it for
+> interactive `ccc` commands like `ccc init`.
 </details>
 
 <details>
 <summary>Codex</summary>
 
 ```bash
-codex mcp add cocoindex-code -- docker exec -i cocoindex-code ccc mcp
+codex mcp add cocoindex-code -- docker exec -i \
+  -e COCOINDEX_CODE_HOST_CWD="$PWD" cocoindex-code ccc mcp
 ```
 </details>
 
-### CLI usage inside the container
+### Upgrading from an older image
 
-All `ccc` commands work via `docker exec`:
-
-```bash
-docker exec -it cocoindex-code ccc index
-docker exec -it cocoindex-code ccc search "authentication logic"
-docker exec -it cocoindex-code ccc status
-```
-
-Or set an alias on your host so it feels native:
+Earlier images used separate `cocoindex-db` and `cocoindex-model-cache`
+volumes; the current image consolidates them into a single `cocoindex-data`
+volume. Before pulling the new image, drop the old container and volumes —
+indexes rebuild on your next `ccc index`, and the embedding model is
+re-populated automatically on first start:
 
 ```bash
-alias ccc='docker exec -it cocoindex-code ccc'
+docker rm -f cocoindex-code
+docker volume rm cocoindex-db cocoindex-model-cache
 ```
 
 ### Configuration via environment variables
 
-Pass configuration to `docker run` with `-e`:
+Pass configuration to `docker run` / compose with `-e`:
 
 ```bash
 # Extra extensions (e.g. Typesafe Config, SBT build files)
@@ -280,6 +336,10 @@ Pass configuration to `docker run` with `-e`:
 # Set an API key
 -e VOYAGE_API_KEY=your-key
 ```
+
+> **Security note:** mounting `$HOME` gives the container read/write access
+> to everything under it. If that's too broad, bind-mount a narrower
+> directory instead (`COCOINDEX_HOST_WORKSPACE=/path/to/code`).
 
 ### Build the image locally
 
@@ -314,6 +374,8 @@ envs:                                                # extra environment variabl
 ```
 
 > **Note:** The daemon inherits your shell environment. If an API key (e.g. `OPENAI_API_KEY`) is already set as an environment variable, you don't need to duplicate it in `envs`. The `envs` field is only for values that aren't in your environment.
+
+> **Custom location:** set `COCOINDEX_CODE_DIR` to place `global_settings.yml` somewhere other than `~/.cocoindex_code/` — useful if you want the file to live alongside your projects (e.g. on a synced folder).
 
 ### Project Settings (`<project>/.cocoindex_code/settings.yml`)
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,59 +3,79 @@
 # Alpine / musl-libc would require building from source.
 FROM python:3.12-slim AS builder
 
-# Install uv via pip — avoids a ghcr.io pull during build
 RUN pip install --quiet uv
 
 WORKDIR /build
 
+# Default: install the released cocoindex-code from PyPI (release flow).
+# Tests/local dev override with:
+#   --build-arg CCC_INSTALL_SPEC=/ccc-src[default]
+# which installs from the copied-in source tree instead. The COPY always runs;
+# with .dockerignore trimming build artifacts it adds ~nothing.
+ARG CCC_INSTALL_SPEC="cocoindex-code[default]"
+COPY . /ccc-src
+
 RUN uv pip install --system --prerelease=allow \
     "cocoindex>=1.0.0a33" \
-    "cocoindex-code[default]"
+    "${CCC_INSTALL_SPEC}"
 
 # ─── Stage 2: pre-bake the default embedding model ────────────────────────────
-# Bakes Snowflake/snowflake-arctic-embed-xs into the image so cold container
-# starts don't trigger a download. Skip this stage (--target builder) if
-# you always supply a global_settings.yml pointing at a non-local model.
+# Bakes Snowflake/snowflake-arctic-embed-xs into the merged data directory at
+# /var/cocoindex/cache/..., so on first run Docker's volume copy-up populates
+# the cocoindex-data volume with the model — no network fetch needed.
 FROM builder AS model_cache
 
-RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('Snowflake/snowflake-arctic-embed-xs'); print('Model cached.')"
+ENV HF_HOME=/var/cocoindex/cache/huggingface \
+    SENTENCE_TRANSFORMERS_HOME=/var/cocoindex/cache/sentence-transformers
+
+RUN mkdir -p /var/cocoindex/cache/huggingface /var/cocoindex/cache/sentence-transformers \
+    && python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('Snowflake/snowflake-arctic-embed-xs'); print('Model cached.')"
 
 # ─── Stage 3: runtime ─────────────────────────────────────────────────────────
 FROM python:3.12-slim AS runtime
 
-# Copy installed packages and cached model from previous stages
+# gosu for privilege-drop (PUID/PGID pattern); create non-root coco user.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gosu \
+    && rm -rf /var/lib/apt/lists/* \
+    && groupadd -g 1000 coco \
+    && useradd -u 1000 -g 1000 -m coco
+
+# Copy installed packages + pre-baked model from previous stages.
 COPY --from=model_cache /usr/local/lib/python3.12 /usr/local/lib/python3.12
 COPY --from=model_cache /usr/local/bin/cocoindex-code /usr/local/bin/cocoindex-code
 COPY --from=model_cache /usr/local/bin/ccc /usr/local/bin/ccc
-COPY --from=model_cache /root/.cache /root/.cache
+COPY --from=model_cache /var/cocoindex/cache /var/cocoindex/cache
 
-# The codebase is mounted at runtime — nothing project-specific lives here.
+# Pre-create writable paths so the entrypoint's chown (under PUID) works even on
+# a fresh container, and so the default root-uid path has them in place.
+RUN mkdir -p /var/cocoindex/db /var/run/cocoindex_code \
+    && chown -R coco:coco /var/cocoindex /var/run/cocoindex_code
+
 WORKDIR /workspace
 
 # ── Runtime defaults (all overridable via -e / --env) ─────────────────────────
+#
+# COCOINDEX_CODE_DIR — holds global_settings.yml on the bind mount so users can
+#   edit it directly on the host.
+# COCOINDEX_CODE_RUNTIME_DIR — keeps daemon.sock/pid/log on the container's
+#   native filesystem (AF_UNIX sockets on bind mounts are unreliable on
+#   Docker Desktop, and /var/run is the standard spot for ephemeral runtime
+#   state — wiped on container recreate, no stale-socket risk).
+# COCOINDEX_CODE_DB_PATH_MAPPING — keeps the indexer's LMDB + SQLite databases
+#   on the native filesystem for speed and correctness.
+# HF_HOME / SENTENCE_TRANSFORMERS_HOME — direct the model cache at the path
+#   the cocoindex-data volume mounts over.
+ENV COCOINDEX_CODE_DIR=/workspace/.cocoindex_code \
+    COCOINDEX_CODE_RUNTIME_DIR=/var/run/cocoindex_code \
+    COCOINDEX_CODE_DB_PATH_MAPPING=/workspace=/var/cocoindex/db \
+    COCOINDEX_CODE_DAEMON_SUPERVISED=1 \
+    HF_HOME=/var/cocoindex/cache/huggingface \
+    SENTENCE_TRANSFORMERS_HOME=/var/cocoindex/cache/sentence-transformers
 
-# Map index databases into the container's native filesystem so SQLite avoids
-# the slow/unreliable cross-OS volume layer (especially on macOS / Windows).
-# Format: /source=/target  — databases for projects under /workspace go to /db.
-ENV COCOINDEX_CODE_DB_PATH_MAPPING=/workspace=/db
+# Set COCOINDEX_CODE_HOST_PATH_MAPPING at run time — it depends on the host path
+# the user bind-mounts to /workspace and can't be baked into the image.
 
-# Additional extensions: add project-specific extras at runtime, e.g.:
-#   -e COCOINDEX_CODE_EXTRA_EXTENSIONS="conf,sbt"
-# See README for ext:lang syntax to map extensions to existing parsers.
-
-# Exclude patterns: override at runtime for your build system, e.g.:
-#   -e COCOINDEX_CODE_EXCLUDE_PATTERNS='["**/target/**","**/node_modules/**"]'
-
-# Embedding model: defaults to local sentence-transformers
-# (Snowflake/snowflake-arctic-embed-xs, pre-baked above).
-# To use a different model, pre-mount a global_settings.yml into
-# ~/.cocoindex_code/ before the container starts, e.g.
-#   -v /path/to/global_settings.yml:/root/.cocoindex_code/global_settings.yml
-
-# ── Persistent daemon entrypoint ──────────────────────────────────────────────
-# Initializes user settings on first start, then runs the daemon in the
-# foreground so the container stays alive.
-# Use `docker exec` to invoke the CLI or start an MCP session — see README.
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,34 @@
+# cocoindex-code — Docker Compose quickstart.
+#
+#   # macOS / Windows
+#   docker compose up -d
+#
+#   # Linux (aligns file ownership with your host user)
+#   PUID=$(id -u) PGID=$(id -g) docker compose up -d
+#
+# By default your home directory is mounted into the container as the
+# workspace. Set COCOINDEX_HOST_WORKSPACE=/path/to/code to mount a narrower
+# directory instead.
+#
+# Using GHCR instead of Docker Hub? Change the image below to
+# `ghcr.io/cocoindex-io/cocoindex-code:latest`.
+
+services:
+  cocoindex-code:
+    image: cocoindex/cocoindex-code:latest
+    container_name: cocoindex-code
+    volumes:
+      - ${COCOINDEX_HOST_WORKSPACE:-${HOME}}:/workspace
+      - cocoindex-data:/var/cocoindex
+    environment:
+      # Makes CLI and MCP output show your real paths
+      # (e.g. `/Users/you/myproject/...`) instead of container paths
+      # (e.g. `/workspace/myproject/...`).
+      COCOINDEX_CODE_HOST_PATH_MAPPING: /workspace=${COCOINDEX_HOST_WORKSPACE:-${HOME}}
+      # Linux only: set these so files written to your workspace are owned by
+      # you rather than root. Not needed on macOS / Windows — leave empty.
+      PUID: ${PUID:-}
+      PGID: ${PGID:-}
+
+volumes:
+  cocoindex-data:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,10 +1,50 @@
 #!/bin/sh
-# Initialize user settings on first run, then hand off to the daemon.
+# Daemon supervisor entrypoint.
+#
+# Runs as PID 1 and keeps the container alive across daemon restarts. The
+# daemon intentionally exits whenever the client issues `StopRequest`
+# (settings-change mtime mismatch, version upgrade, etc.); the `while`
+# loop respawns it in place so the container stays up.
+#
+# Why not `exec ccc run-daemon`: if the daemon were PID 1, any daemon
+# exit would take the container down with it — breaking auto-restart on
+# `global_settings.yml` edits.
+#
+# The SIGTERM/SIGINT trap forwards `docker stop` to the daemon child so
+# graceful shutdown still flows through the normal cleanup path.
 set -e
 
-# `ccc init` creates ~/.cocoindex_code/global_settings.yml with the default
-# embedding model if the file doesn't already exist. Pre-mount a custom
-# global_settings.yml to override (see Dockerfile comments).
-ccc init -f 2>/dev/null || true
+if [ -n "$PUID" ] && [ -n "$PGID" ]; then
+    groupmod -o -g "$PGID" coco
+    usermod -o -u "$PUID" coco
+    chown -R coco:coco /var/cocoindex /var/run/cocoindex_code
+    if [ -d /workspace/.cocoindex_code ]; then
+        chown coco:coco /workspace/.cocoindex_code 2>/dev/null || true
+    fi
+fi
 
-exec ccc run-daemon
+run_daemon() {
+    if [ -n "$PUID" ] && [ -n "$PGID" ]; then
+        gosu coco ccc run-daemon
+    else
+        ccc run-daemon
+    fi
+}
+
+child=""
+trap 'if [ -n "$child" ]; then kill -TERM "$child" 2>/dev/null; wait "$child" 2>/dev/null; fi; exit 0' TERM INT
+
+while true; do
+    start_ts=$(date +%s)
+    run_daemon &
+    child=$!
+    wait "$child" || true
+    # Rate-limit respawns: sleep just long enough that successive starts are
+    # >=1s apart. A clean settings-change exit with a long-running daemon
+    # doesn't pay the 1s tax — only tight crash loops do.
+    now=$(date +%s)
+    delay=$((start_ts + 1 - now))
+    if [ "$delay" -gt 0 ]; then
+        sleep "$delay"
+    fi
+done

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,5 +105,8 @@ explicit_package_bases = true
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short"
+addopts = "-v --tb=short -m 'not docker_e2e'"
 asyncio_mode = "auto"
+markers = [
+    "docker_e2e: requires Docker; builds the image and runs containerized E2E tests. Run with: pytest -m docker_e2e",
+]

--- a/src/cocoindex_code/_daemon_paths.py
+++ b/src/cocoindex_code/_daemon_paths.py
@@ -6,14 +6,28 @@ can import these without pulling in the full daemon stack.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
 from .settings import user_settings_dir
 
 
-def daemon_dir() -> Path:
-    """Return the daemon directory (``~/.cocoindex_code/``)."""
+def daemon_runtime_dir() -> Path:
+    """Return the directory that holds daemon runtime artifacts.
+
+    Holds ``daemon.sock``, ``daemon.pid``, ``daemon.log``. Kept separate from
+    the user-settings dir so that (e.g. in Docker) the socket can live on the
+    container's native filesystem while ``global_settings.yml`` lives on a
+    bind mount.
+
+    Override with ``COCOINDEX_CODE_RUNTIME_DIR``. Defaults to
+    :func:`user_settings_dir` for backward compatibility — non-Docker users
+    see identical behavior to before the split.
+    """
+    override = os.environ.get("COCOINDEX_CODE_RUNTIME_DIR")
+    if override:
+        return Path(override)
     return user_settings_dir()
 
 
@@ -27,18 +41,20 @@ def daemon_socket_path() -> str:
     if sys.platform == "win32":
         import hashlib
 
-        # Hash the daemon dir so COCOINDEX_CODE_DIR overrides create unique pipe names,
-        # preventing conflicts between different daemon instances (tests, users, etc.)
-        dir_hash = hashlib.md5(str(daemon_dir()).encode()).hexdigest()[:12]
+        # Hash the runtime dir so COCOINDEX_CODE_RUNTIME_DIR (or the
+        # COCOINDEX_CODE_DIR fallback) overrides produce unique pipe names,
+        # preventing conflicts between different daemon instances (tests,
+        # users, etc.)
+        dir_hash = hashlib.md5(str(daemon_runtime_dir()).encode()).hexdigest()[:12]
         return rf"\\.\pipe\cocoindex_code_{dir_hash}"
-    return str(daemon_dir() / "daemon.sock")
+    return str(daemon_runtime_dir() / "daemon.sock")
 
 
 def daemon_pid_path() -> Path:
     """Return the path for the daemon's PID file."""
-    return daemon_dir() / "daemon.pid"
+    return daemon_runtime_dir() / "daemon.pid"
 
 
 def daemon_log_path() -> Path:
     """Return the path for the daemon's log file."""
-    return daemon_dir() / "daemon.log"
+    return daemon_runtime_dir() / "daemon.log"

--- a/src/cocoindex_code/cli.py
+++ b/src/cocoindex_code/cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import functools
+import os
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -19,6 +20,8 @@ from .settings import (
     default_project_settings,
     find_parent_with_marker,
     find_project_root,
+    format_path_for_display,
+    normalize_input_path,
     project_settings_path,
     resolve_db_dir,
     save_initial_user_settings,
@@ -37,6 +40,29 @@ daemon_app = _typer.Typer(name="daemon", help="Manage the daemon process.")
 app.add_typer(daemon_app, name="daemon")
 
 
+@app.callback()
+def _apply_host_cwd() -> None:
+    """Honor ``COCOINDEX_CODE_HOST_CWD`` when forwarded from a ``docker exec`` wrapper.
+
+    The env var carries the host shell's pwd verbatim. We normalize it through
+    the host path mapping to container form and ``chdir`` there so
+    cwd-driven discovery (``find_project_root`` etc.) sees the user's real
+    project subtree. Unset → no-op.
+    """
+    host_cwd = os.environ.get("COCOINDEX_CODE_HOST_CWD")
+    if not host_cwd:
+        return
+    target = normalize_input_path(host_cwd)
+    try:
+        os.chdir(target)
+    except OSError as e:
+        _typer.echo(
+            f"Warning: COCOINDEX_CODE_HOST_CWD={host_cwd!r} → {target!r} "
+            f"is not accessible: {e}. Continuing with cwd={os.getcwd()!r}.",
+            err=True,
+        )
+
+
 # ---------------------------------------------------------------------------
 # Shared CLI helpers
 # ---------------------------------------------------------------------------
@@ -51,7 +77,7 @@ def require_project_root() -> Path:
     gs_path = user_settings_path()
     if not gs_path.is_file():
         _typer.echo(
-            f"Error: Global settings not found: {gs_path}\n"
+            f"Error: Global settings not found: {format_path_for_display(gs_path)}\n"
             "Run `ccc init` to create it with default settings.",
             err=True,
         )
@@ -112,7 +138,7 @@ def _format_progress(progress: IndexingProgress) -> str:
 
 def print_project_header(project_root: str) -> None:
     """Print the project root directory."""
-    _typer.echo(f"Project: {project_root}")
+    _typer.echo(f"Project: {format_path_for_display(project_root)}")
 
 
 def print_index_stats(status: ProjectStatusResponse) -> None:
@@ -400,8 +426,9 @@ def _run_init_model_check(settings_path: Path) -> None:
             failed = True
 
     if failed:
+        display_path = format_path_for_display(settings_path)
         _typer.echo(
-            f"You can edit {settings_path} to change the model or add API keys\n"
+            f"You can edit {display_path} to change the model or add API keys\n"
             "under `envs:`. Then run `ccc doctor` to verify.",
             err=True,
         )
@@ -419,7 +446,7 @@ def _setup_user_settings_interactive(litellm_model_flag: str | None) -> None:
 
     path = save_initial_user_settings(embedding)
     _typer.echo()
-    _typer.echo(f"Created user settings: {path}")
+    _typer.echo(f"Created user settings: {format_path_for_display(path)}")
 
     _typer.echo()
     _typer.echo(f"Testing embedding model: {embedding.provider} / {embedding.model}")
@@ -443,8 +470,9 @@ def init(
     user_path = user_settings_path()
     if user_path.is_file():
         if litellm_model is not None:
+            display_path = format_path_for_display(user_path)
             _typer.echo(
-                f"Error: global settings already exist at {user_path}.\n"
+                f"Error: global settings already exist at {display_path}.\n"
                 "Edit that file or remove it before passing `--litellm-model`.",
                 err=True,
             )
@@ -461,8 +489,9 @@ def init(
     if not force:
         parent = find_parent_with_marker(cwd)
         if parent is not None and parent != cwd:
+            display_parent = format_path_for_display(parent)
             _typer.echo(
-                f"Warning: A parent directory has a project marker: {parent}\n"
+                f"Warning: A parent directory has a project marker: {display_parent}\n"
                 "You might want to run `ccc init` there instead.\n"
                 "Use `ccc init -f` to initialize here anyway."
             )
@@ -470,7 +499,7 @@ def init(
 
     # Create project settings
     save_project_settings(cwd, default_project_settings())
-    _typer.echo(f"Created project settings: {settings_file}")
+    _typer.echo(f"Created project settings: {format_path_for_display(settings_file)}")
 
     # Add to .gitignore
     add_to_gitignore(cwd)
@@ -538,10 +567,10 @@ def status() -> None:
     project_root = str(project_root_path)
     print_project_header(project_root)
 
-    _typer.echo(f"Settings: {project_settings_path(project_root_path)}")
+    _typer.echo(f"Settings: {format_path_for_display(project_settings_path(project_root_path))}")
     db_path = target_sqlite_db_path(project_root_path)
     if db_path.exists():
-        _typer.echo(f"Index DB: {db_path}")
+        _typer.echo(f"Index DB: {format_path_for_display(db_path)}")
 
     print_index_stats(_client.project_status(project_root))
 
@@ -576,7 +605,7 @@ def reset(
     if to_delete:
         _typer.echo("The following files will be deleted:")
         for f in to_delete:
-            _typer.echo(f"  {f}")
+            _typer.echo(f"  {format_path_for_display(f)}")
 
     # Confirm
     if not force:
@@ -668,7 +697,7 @@ def doctor() -> None:
     # --- 1. Global settings (local, no daemon needed) ---
     _print_section("Global Settings")
     settings_path = user_settings_path()
-    _typer.echo(f"  Settings: {settings_path}")
+    _typer.echo(f"  Settings: {format_path_for_display(settings_path)}")
     try:
         user_settings = _load_user_settings()
         emb = user_settings.embedding
@@ -706,6 +735,10 @@ def doctor() -> None:
                 _typer.echo("  DB path mappings:")
                 for m in env_resp.db_path_mappings:
                     _typer.echo(f"    {m.source} \u2192 {m.target}")
+            if env_resp.host_path_mappings:
+                _typer.echo("  Host path mappings:")
+                for m in env_resp.host_path_mappings:
+                    _typer.echo(f"    {m.source} \u2192 {m.target}")
         except Exception as e:
             _print_error(f"Failed to get daemon env: {e}")
 
@@ -726,7 +759,7 @@ def doctor() -> None:
     if project_root is not None:
         _print_section("Project Settings")
         ps_path = project_settings_path(project_root)
-        _typer.echo(f"  Settings: {ps_path}")
+        _typer.echo(f"  Settings: {format_path_for_display(ps_path)}")
         try:
             ps = _load_project_settings(project_root)
             _typer.echo(f"  Include patterns ({len(ps.include_patterns)}):")
@@ -754,7 +787,7 @@ def doctor() -> None:
     _print_section("Log Files")
     from ._daemon_paths import daemon_log_path as _daemon_log_path
 
-    _typer.echo(f"  Daemon logs: {_daemon_log_path()}")
+    _typer.echo(f"  Daemon logs: {format_path_for_display(_daemon_log_path())}")
     _typer.echo("  Check logs above for further troubleshooting.")
 
 
@@ -805,7 +838,7 @@ def daemon_status() -> None:
         _typer.echo("Projects:")
         for p in resp.projects:
             state = "indexing" if p.indexing else "idle"
-            _typer.echo(f"  {p.project_root} [{state}]")
+            _typer.echo(f"  {format_path_for_display(p.project_root)} [{state}]")
     else:
         _typer.echo("No projects loaded.")
 

--- a/src/cocoindex_code/client.py
+++ b/src/cocoindex_code/client.py
@@ -19,9 +19,9 @@ from pathlib import Path
 
 from ._daemon_paths import (
     connection_family,
-    daemon_dir,
     daemon_log_path,
     daemon_pid_path,
+    daemon_runtime_dir,
     daemon_socket_path,
 )
 from ._version import __version__
@@ -53,6 +53,7 @@ from .protocol import (
     decode_response,
     encode_request,
 )
+from .settings import normalize_input_path
 
 logger = logging.getLogger(__name__)
 
@@ -63,6 +64,14 @@ logger = logging.getLogger(__name__)
 
 
 _daemon_ensured = False
+
+
+def _is_daemon_supervised() -> bool:
+    """True when an external supervisor (Docker entrypoint loop, systemd, …) owns
+    daemon respawn. The client in that mode calls ``stop_daemon`` but never
+    ``start_daemon`` — it just waits for the socket to reappear.
+    """
+    return os.environ.get("COCOINDEX_CODE_DAEMON_SUPERVISED") == "1"
 
 
 def _connect_and_handshake() -> Connection:
@@ -90,8 +99,13 @@ def _connect_and_handshake() -> Connection:
     except (ConnectionRefusedError, OSError):
         pass
 
-    proc = start_daemon()
-    _wait_for_daemon(proc=proc)
+    if _is_daemon_supervised():
+        # Supervisor is responsible for (re)starting the daemon — just wait
+        # for the socket to reappear.
+        _wait_for_daemon()
+    else:
+        proc = start_daemon()
+        _wait_for_daemon(proc=proc)
 
     # Verify the fresh daemon is reachable
     for _attempt in range(10):
@@ -199,6 +213,7 @@ def index(
     on_waiting: Callable[[], None] | None = None,
 ) -> IndexResponse:
     """Request indexing with streaming progress. Blocks until complete."""
+    project_root = normalize_input_path(project_root)
     conn = _connect_and_handshake()
     try:
         conn.send_bytes(encode_request(IndexRequest(project_root=project_root)))
@@ -240,6 +255,7 @@ def search(
     progress), calls *on_waiting* (if provided) then continues reading
     until the final ``SearchResponse``.
     """
+    project_root = normalize_input_path(project_root)
     conn = _connect_and_handshake()
     try:
         conn.send_bytes(
@@ -274,7 +290,7 @@ def search(
 
 
 def project_status(project_root: str) -> ProjectStatusResponse:
-    return _send(ProjectStatusRequest(project_root=project_root))  # type: ignore[return-value]
+    return _send(ProjectStatusRequest(project_root=normalize_input_path(project_root)))  # type: ignore[return-value]
 
 
 def daemon_status() -> DaemonStatusResponse:
@@ -284,7 +300,7 @@ def daemon_status() -> DaemonStatusResponse:
 
 
 def remove_project(project_root: str) -> RemoveProjectResponse:
-    return _send(RemoveProjectRequest(project_root=project_root))  # type: ignore[return-value]
+    return _send(RemoveProjectRequest(project_root=normalize_input_path(project_root)))  # type: ignore[return-value]
 
 
 def stop() -> StopResponse:
@@ -301,6 +317,8 @@ def doctor(
     on_result: Callable[[DoctorCheckResult], None] | None = None,
 ) -> list[DoctorCheckResult]:
     """Run doctor checks via daemon, streaming results to on_result callback."""
+    if project_root is not None:
+        project_root = normalize_input_path(project_root)
     conn = _connect_and_handshake()
     try:
         conn.send_bytes(encode_request(DoctorRequest(project_root=project_root)))
@@ -349,7 +367,7 @@ def start_daemon() -> subprocess.Popen[bytes]:
     Returns the ``Popen`` object so callers can detect early process death
     (via ``proc.poll()``) instead of waiting for a full timeout.
     """
-    daemon_dir().mkdir(parents=True, exist_ok=True)
+    daemon_runtime_dir().mkdir(parents=True, exist_ok=True)
     log_path = daemon_log_path()
 
     ccc_path = _find_ccc_executable()
@@ -508,18 +526,16 @@ def _wait_for_daemon(
     If *proc* is given, polls the process each iteration.  When the process
     exits before the socket appears, raises ``DaemonStartError`` immediately
     with the daemon log content — no need to wait for the full timeout.
+
+    Socket existence is checked *before* ``proc.poll()`` so that races with a
+    supervisor (e.g. the Docker entrypoint restart loop) don't spuriously raise
+    ``DaemonStartError``: if the supervisor wins the bind and our subprocess
+    exits because the socket is already in use, the socket is still ready — we
+    should return success, not flag a failure.
     """
     deadline = time.monotonic() + timeout
     sock_path = daemon_socket_path()
     while time.monotonic() < deadline:
-        # Check if the daemon process died before the socket appeared.
-        if proc is not None and proc.poll() is not None:
-            log = _read_daemon_log()
-            msg = "Daemon process exited before it became ready."
-            if log:
-                msg += f"\n\nDaemon log:\n{log}"
-            raise DaemonStartError(msg, log=log)
-
         if sys.platform == "win32":
             try:
                 conn = Client(sock_path, family=connection_family())
@@ -530,6 +546,16 @@ def _wait_for_daemon(
         else:
             if os.path.exists(sock_path):
                 return
+
+        # Daemon socket not yet up — if we spawned a subprocess that already
+        # exited, bail out with its log.
+        if proc is not None and proc.poll() is not None:
+            log = _read_daemon_log()
+            msg = "Daemon process exited before it became ready."
+            if log:
+                msg += f"\n\nDaemon log:\n{log}"
+            raise DaemonStartError(msg, log=log)
+
         time.sleep(0.2)
 
     # Timeout — also include log for diagnostics.

--- a/src/cocoindex_code/daemon.py
+++ b/src/cocoindex_code/daemon.py
@@ -17,9 +17,9 @@ from typing import Any
 
 from ._daemon_paths import (
     connection_family,
-    daemon_dir,
     daemon_log_path,
     daemon_pid_path,
+    daemon_runtime_dir,
     daemon_socket_path,
 )
 from ._version import __version__
@@ -56,10 +56,13 @@ from .protocol import (
 )
 from .settings import (
     ChunkerMapping,
+    format_path_for_display,
+    get_host_path_mappings,
     global_settings_mtime_us,
     load_project_settings,
     load_user_settings,
     target_sqlite_db_path,
+    user_settings_path,
 )
 from .shared import Embedder, check_embedding, create_embedder
 
@@ -91,17 +94,28 @@ def _resolve_chunker_registry(mappings: list[ChunkerMapping]) -> dict[str, _Chun
 
 
 class ProjectRegistry:
-    """Cache of loaded projects, keyed by project root path."""
+    """Cache of loaded projects, keyed by project root path.
+
+    ``_embedder`` is ``None`` when the daemon is running in "no-settings mode"
+    (started before ``global_settings.yml`` existed). In that state
+    ``get_project`` raises an error pointing the user at ``ccc init``; the
+    daemon still serves handshakes so the client can detect the mtime
+    mismatch once the file is created and trigger a supervisor respawn.
+    """
 
     _projects: dict[str, Project]
-    _embedder: Embedder
+    _embedder: Embedder | None
 
-    def __init__(self, embedder: Embedder) -> None:
+    def __init__(self, embedder: Embedder | None) -> None:
         self._projects = {}
         self._embedder = embedder
 
     async def get_project(self, project_root: str) -> Project:
         """Get or create a Project for the given root. Lazy initialization."""
+        if self._embedder is None:
+            raise RuntimeError(
+                "Daemon has no global settings loaded. Run `ccc init` to set up cocoindex-code."
+            )
         if project_root not in self._projects:
             root = Path(project_root)
             project_settings = load_project_settings(root)
@@ -260,8 +274,19 @@ async def _handle_doctor(
     )
 
 
-async def _check_model(embedder: Embedder) -> DoctorCheckResult:
-    """Test the embedding model by embedding a short string."""
+async def _check_model(embedder: Embedder | None) -> DoctorCheckResult:
+    """Test the embedding model by embedding a short string.
+
+    Returns a failed result when the embedder is ``None`` (daemon running in
+    no-settings mode).
+    """
+    if embedder is None:
+        return DoctorCheckResult(
+            name="Model Check",
+            ok=False,
+            details=[],
+            errors=["Daemon has no global settings loaded. Run `ccc init` to set up."],
+        )
     result = await check_embedding(embedder)
     if result.error is None:
         return DoctorCheckResult(
@@ -340,7 +365,7 @@ async def _check_index_status(project_root_str: str) -> DoctorCheckResult:
 
     project_root = Path(project_root_str)
     db_path = target_sqlite_db_path(project_root)
-    details = [f"Index: {db_path}"]
+    details = [f"Index: {format_path_for_display(db_path)}"]
 
     if not db_path.exists():
         details.append("Index not created yet.")
@@ -445,6 +470,10 @@ async def _dispatch(
                     DbPathMappingEntry(source=str(m.source), target=str(m.target))
                     for m in get_db_path_mappings()
                 ],
+                host_path_mappings=[
+                    DbPathMappingEntry(source=str(m.source), target=str(m.target))
+                    for m in get_host_path_mappings()
+                ],
             )
 
         if isinstance(req, DoctorRequest):
@@ -468,19 +497,24 @@ def run_daemon() -> None:
     to serve connections, and performs cleanup when shutdown is requested via
     ``StopRequest`` or a signal (SIGTERM / SIGINT).
     """
-    daemon_dir().mkdir(parents=True, exist_ok=True)
+    daemon_runtime_dir().mkdir(parents=True, exist_ok=True)
 
-    # Load user settings and record mtime for staleness detection
-    user_settings = load_user_settings()
-    settings_mtime_us = global_settings_mtime_us()
-
-    # Set environment variables from settings
-    settings_env_keys = list(user_settings.envs.keys())
-    for key, value in user_settings.envs.items():
-        os.environ[key] = value
-
-    # Create embedder
-    embedder = create_embedder(user_settings.embedding)
+    # No-settings mode: start even when global_settings.yml is missing so the
+    # client can complete its handshake, detect the mtime mismatch once
+    # `ccc init` writes the file, and trigger a supervisor respawn. The
+    # alternative (auto-creating defaults) would skip the interactive
+    # provider/model picker in `ccc init`.
+    settings_mtime_us = global_settings_mtime_us()  # None when file is missing
+    embedder: Embedder | None
+    if user_settings_path().is_file():
+        user_settings = load_user_settings()
+        settings_env_keys = list(user_settings.envs.keys())
+        for key, value in user_settings.envs.items():
+            os.environ[key] = value
+        embedder = create_embedder(user_settings.embedding)
+    else:
+        settings_env_keys = []
+        embedder = None
 
     # Write PID file
     pid_path = daemon_pid_path()

--- a/src/cocoindex_code/protocol.py
+++ b/src/cocoindex_code/protocol.py
@@ -167,6 +167,7 @@ class DaemonEnvResponse(_msgspec.Struct, tag="daemon_env"):
     env_names: list[str]
     settings_env_names: list[str]
     db_path_mappings: list[DbPathMappingEntry] = []
+    host_path_mappings: list[DbPathMappingEntry] = []
 
 
 class ErrorResponse(_msgspec.Struct, tag="error"):

--- a/src/cocoindex_code/settings.py
+++ b/src/cocoindex_code/settings.py
@@ -151,49 +151,66 @@ _SETTINGS_FILE_NAME = "settings.yml"  # project-level
 _USER_SETTINGS_FILE_NAME = "global_settings.yml"  # user-level
 
 _ENV_DB_PATH_MAPPING = "COCOINDEX_CODE_DB_PATH_MAPPING"
+_ENV_HOST_PATH_MAPPING = "COCOINDEX_CODE_HOST_PATH_MAPPING"
 
 
 @dataclass
-class DbPathMapping:
+class PathMapping:
     source: Path
     target: Path
 
 
-_db_path_mapping: list[DbPathMapping] | None = None
+def _parse_path_mapping(env_var: str) -> list[PathMapping]:
+    """Parse a ``source=target[,source=target...]`` env var.
 
-
-def _parse_db_path_mapping() -> list[DbPathMapping]:
-    """Parse ``COCOINDEX_CODE_DB_PATH_MAPPING`` env var.
-
-    Format: ``/src1=/dst1,/src2=/dst2``
-    Both source and target must be absolute paths.
+    Both source and target must be absolute paths. Returns an empty list when
+    the env var is unset or blank. Raises ``ValueError`` on malformed entries.
     """
-    raw = os.environ.get(_ENV_DB_PATH_MAPPING, "")
+    raw = os.environ.get(env_var, "")
     if not raw.strip():
         return []
 
-    mappings: list[DbPathMapping] = []
+    mappings: list[PathMapping] = []
     for entry in raw.split(","):
         entry = entry.strip()
         if not entry:
             continue
         parts = entry.split("=", 1)
         if len(parts) != 2 or not parts[0] or not parts[1]:
-            raise ValueError(
-                f"{_ENV_DB_PATH_MAPPING}: invalid entry {entry!r}, expected format 'source=target'"
-            )
+            raise ValueError(f"{env_var}: invalid entry {entry!r}, expected format 'source=target'")
         source = Path(parts[0])
         target = Path(parts[1])
         if not source.is_absolute():
-            raise ValueError(
-                f"{_ENV_DB_PATH_MAPPING}: source path must be absolute, got {source!r}"
-            )
+            raise ValueError(f"{env_var}: source path must be absolute, got {source!r}")
         if not target.is_absolute():
-            raise ValueError(
-                f"{_ENV_DB_PATH_MAPPING}: target path must be absolute, got {target!r}"
-            )
-        mappings.append(DbPathMapping(source=source.resolve(), target=target.resolve()))
+            raise ValueError(f"{env_var}: target path must be absolute, got {target!r}")
+        mappings.append(PathMapping(source=source.resolve(), target=target.resolve()))
     return mappings
+
+
+def _apply_mapping(mappings: list[PathMapping], path: str | Path, reverse: bool = False) -> str:
+    """Rewrite ``path`` through ``mappings``. First prefix match wins.
+
+    ``reverse=False``: rewrites source-prefix → target-prefix (forward).
+    ``reverse=True``: rewrites target-prefix → source-prefix (reverse).
+
+    Relative paths and absolute paths with no matching prefix are returned
+    unchanged (as ``str``).
+    """
+    p = Path(path)
+    if not p.is_absolute():
+        return str(path)
+    resolved = p.resolve()
+    for m in mappings:
+        src, dst = (m.target, m.source) if reverse else (m.source, m.target)
+        if resolved == src or resolved.is_relative_to(src):
+            rel = resolved.relative_to(src)
+            return str(dst / rel) if str(rel) != "." else str(dst)
+    return str(path)
+
+
+_db_path_mapping: list[PathMapping] | None = None
+_host_path_mapping: list[PathMapping] | None = None
 
 
 def resolve_db_dir(project_root: Path) -> Path:
@@ -204,7 +221,7 @@ def resolve_db_dir(project_root: Path) -> Path:
     """
     global _db_path_mapping  # noqa: PLW0603
     if _db_path_mapping is None:
-        _db_path_mapping = _parse_db_path_mapping()
+        _db_path_mapping = _parse_path_mapping(_ENV_DB_PATH_MAPPING)
 
     resolved = project_root.resolve()
     for mapping in _db_path_mapping:
@@ -214,18 +231,50 @@ def resolve_db_dir(project_root: Path) -> Path:
     return project_root / _SETTINGS_DIR_NAME
 
 
-def get_db_path_mappings() -> list[DbPathMapping]:
+def get_db_path_mappings() -> list[PathMapping]:
     """Return the parsed DB path mappings from ``COCOINDEX_CODE_DB_PATH_MAPPING``."""
     global _db_path_mapping  # noqa: PLW0603
     if _db_path_mapping is None:
-        _db_path_mapping = _parse_db_path_mapping()
+        _db_path_mapping = _parse_path_mapping(_ENV_DB_PATH_MAPPING)
     return list(_db_path_mapping)
+
+
+def get_host_path_mappings() -> list[PathMapping]:
+    """Return the parsed host path mappings from ``COCOINDEX_CODE_HOST_PATH_MAPPING``."""
+    global _host_path_mapping  # noqa: PLW0603
+    if _host_path_mapping is None:
+        _host_path_mapping = _parse_path_mapping(_ENV_HOST_PATH_MAPPING)
+    return list(_host_path_mapping)
+
+
+def format_path_for_display(p: str | Path) -> str:
+    """Translate a container path to its host equivalent for user-facing output.
+
+    No-op when ``COCOINDEX_CODE_HOST_PATH_MAPPING`` is unset or when ``p`` is a
+    relative path / unmatched absolute path.
+    """
+    return _apply_mapping(get_host_path_mappings(), p, reverse=False)
+
+
+def normalize_input_path(p: str | Path) -> str:
+    """Translate a host path back to its container form before using it internally.
+
+    Inverse of :func:`format_path_for_display`. No-op when the env var is unset
+    or when ``p`` is relative / unmatched.
+    """
+    return _apply_mapping(get_host_path_mappings(), p, reverse=True)
 
 
 def _reset_db_path_mapping_cache() -> None:
     """Reset the cached mapping (for tests)."""
     global _db_path_mapping  # noqa: PLW0603
     _db_path_mapping = None
+
+
+def _reset_host_path_mapping_cache() -> None:
+    """Reset the cached mapping (for tests)."""
+    global _host_path_mapping  # noqa: PLW0603
+    _host_path_mapping = None
 
 
 _TARGET_SQLITE_DB_NAME = "target_sqlite.db"
@@ -295,22 +344,27 @@ def find_legacy_project_root(start: Path) -> Path | None:
 
 
 def find_parent_with_marker(start: Path) -> Path | None:
-    """Walk up from *start* looking for ``.cocoindex_code/`` or ``.git/``.
+    """Walk up from *start* looking for an initialized project or a git repo.
 
-    Returns the first directory found, or ``None``.
-    Does not consider the home directory or above, to avoid false positives
-    on CI runners where ~/.git may exist.
+    Match criteria: ``.cocoindex_code/settings.yml`` (a real project marker —
+    distinct from a workspace-root ``.cocoindex_code/global_settings.yml``
+    which should not trigger this check) or ``.git/``.
+
+    Returns the first directory found, or ``None``. Does not consider the home
+    directory or above, to avoid false positives on CI runners where ~/.git
+    may exist.
     """
     home = Path.home().resolve()
     current = start.resolve()
     while True:
-        # Stop before reaching the home directory (home itself is not a project root)
         if current == home:
             return None
         parent = current.parent
         if parent == current:
             return None
-        if (current / _SETTINGS_DIR_NAME).is_dir() or (current / ".git").is_dir():
+        if (current / _SETTINGS_DIR_NAME / _SETTINGS_FILE_NAME).is_file() or (
+            current / ".git"
+        ).is_dir():
             return current
         current = parent
 

--- a/tests/e2e_docker/conftest.py
+++ b/tests/e2e_docker/conftest.py
@@ -1,0 +1,117 @@
+"""Shared fixtures for Dockerized end-to-end tests.
+
+All tests here are gated behind the ``docker_e2e`` pytest marker AND a
+``skipif not docker_available()`` so that missing Docker on the host skips
+cleanly instead of failing.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import time
+import uuid
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCKERFILE = REPO_ROOT / "docker" / "Dockerfile"
+FIXTURE_PROJECT = REPO_ROOT / "tests" / "e2e_docker_fixtures" / "sample_project"
+
+
+@pytest.fixture(scope="session")
+def docker_image() -> str:
+    """Build the image once per test session, installing cocoindex-code from the
+    local source tree (not PyPI) so tests exercise the current changes. Returns the tag.
+    """
+    tag = "cocoindex-code:pytest"
+    subprocess.run(
+        [
+            "docker",
+            "build",
+            "-f",
+            str(DOCKERFILE),
+            "--build-arg",
+            "CCC_INSTALL_SPEC=/ccc-src[default]",
+            "-t",
+            tag,
+            str(REPO_ROOT),
+        ],
+        check=True,
+    )
+    return tag
+
+
+@pytest.fixture()
+def fixture_workspace(tmp_path: Path) -> Path:
+    """A fresh copy of the sample project, bind-mountable into the container.
+
+    Each test gets its own copy so that one test's index state / settings
+    don't bleed into another.
+    """
+    dst = tmp_path / "workspace"
+    shutil.copytree(FIXTURE_PROJECT, dst)
+    return dst
+
+
+@pytest.fixture()
+def container(
+    docker_image: str,
+    fixture_workspace: Path,
+) -> Iterator[str]:
+    """Start a fresh container with the sample project bind-mounted at /workspace.
+
+    Uses an anonymous cocoindex-data volume so each test starts with a clean
+    DB / model cache (the image's copy-up populates the cache from the
+    baked-in path).
+    """
+    name = f"ccc-e2e-{uuid.uuid4().hex[:12]}"
+    host_ws = str(fixture_workspace)
+    try:
+        subprocess.run(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--rm",
+                "--name",
+                name,
+                "-v",
+                f"{host_ws}:/workspace",
+                "-v",
+                "/var/cocoindex",  # anonymous volume per-test
+                "-e",
+                f"COCOINDEX_CODE_HOST_PATH_MAPPING=/workspace={host_ws}",
+                docker_image,
+            ],
+            check=True,
+            capture_output=True,
+        )
+        # Poll for the daemon socket so we know startup finished.
+        _wait_for_daemon_ready(name, timeout=30.0)
+        yield name
+    finally:
+        subprocess.run(["docker", "rm", "-f", name], capture_output=True, check=False)
+
+
+def _wait_for_daemon_ready(container_name: str, timeout: float) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            [
+                "docker",
+                "exec",
+                container_name,
+                "sh",
+                "-c",
+                "test -S /var/run/cocoindex_code/daemon.sock",
+            ],
+            capture_output=True,
+            check=False,
+        )
+        if result.returncode == 0:
+            return
+        time.sleep(0.5)
+    raise TimeoutError(f"Daemon in {container_name} did not become ready within {timeout}s")

--- a/tests/e2e_docker/test_docker_workspace.py
+++ b/tests/e2e_docker/test_docker_workspace.py
@@ -1,0 +1,369 @@
+"""End-to-end tests exercising the full Docker setup.
+
+Gated behind the ``docker_e2e`` marker (excluded from the default pytest run).
+Run with: ``uv run pytest -m docker_e2e``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    try:
+        result = subprocess.run(["docker", "info"], capture_output=True, timeout=5, check=False)
+    except (subprocess.TimeoutExpired, OSError):
+        return False
+    return result.returncode == 0
+
+
+pytestmark = [
+    pytest.mark.docker_e2e,
+    pytest.mark.skipif(not _docker_available(), reason="Docker not available on this host"),
+]
+
+
+def docker_exec(
+    container_name: str,
+    argv: list[str],
+    env: dict[str, str] | None = None,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Thin wrapper over ``docker exec`` that captures stdout/stderr as text."""
+    cmd = ["docker", "exec"]
+    for k, v in (env or {}).items():
+        cmd.extend(["-e", f"{k}={v}"])
+    cmd.append(container_name)
+    cmd.extend(argv)
+    return subprocess.run(cmd, capture_output=True, text=True, check=check)
+
+
+def test_index_and_search_happy_path(container: str, fixture_workspace: Path) -> None:
+    """Baseline flow: daemon comes up, `ccc init` writes settings and triggers
+    supervised respawn, `ccc index` succeeds, `ccc search` returns hits.
+    """
+    # Container starts with no global_settings.yml; daemon is in no-settings mode.
+    # `ccc init -f` writes defaults (no TTY → falls back to default st model).
+    docker_exec(
+        container,
+        ["ccc", "init", "-f"],
+        env={"COCOINDEX_CODE_HOST_CWD": str(fixture_workspace)},
+    )
+
+    index_result = docker_exec(
+        container,
+        ["ccc", "index"],
+        env={"COCOINDEX_CODE_HOST_CWD": str(fixture_workspace)},
+    )
+    assert index_result.returncode == 0, index_result.stderr
+
+    search = docker_exec(
+        container,
+        ["ccc", "search", "password", "verification"],
+        env={"COCOINDEX_CODE_HOST_CWD": str(fixture_workspace)},
+    )
+    assert search.returncode == 0, search.stderr
+    # Relative path — unchanged by host-path mapping, identical to what a
+    # host-side `ccc` would print.
+    assert "src/auth.py" in search.stdout
+
+
+def test_host_cwd_forwarding_resolves_project(container: str, fixture_workspace: Path) -> None:
+    """With COCOINDEX_CODE_HOST_CWD set, subproject-cwd commands find the right project."""
+    docker_exec(
+        container,
+        ["ccc", "init", "-f"],
+        env={"COCOINDEX_CODE_HOST_CWD": str(fixture_workspace)},
+    )
+
+    # Invoke `ccc status` from the host-form subdirectory path.
+    status = docker_exec(
+        container,
+        ["ccc", "status"],
+        env={"COCOINDEX_CODE_HOST_CWD": str(fixture_workspace / "src")},
+    )
+    assert status.returncode == 0, status.stderr
+    # Project header should show the HOST path (translated via the mapping),
+    # rooted at the host workspace — not /workspace.
+    assert str(fixture_workspace) in status.stdout
+
+
+def test_host_cwd_invalid_warns_but_continues(container: str) -> None:
+    """An unresolvable host-cwd emits a stderr warning; the command still runs."""
+    result = docker_exec(
+        container,
+        ["ccc", "daemon", "status"],
+        env={"COCOINDEX_CODE_HOST_CWD": "/nonexistent/zzz"},
+        check=False,
+    )
+    assert "COCOINDEX_CODE_HOST_CWD" in result.stderr
+    assert result.returncode == 0
+
+
+def test_settings_change_triggers_supervised_restart(
+    container: str, fixture_workspace: Path
+) -> None:
+    """Editing ``global_settings.yml`` should cause the next CLI call to
+    restart the daemon via the entrypoint's respawn loop — not take the
+    container down.
+    """
+    import time
+
+    # First pass — daemon in no-settings mode writes settings via init.
+    docker_exec(
+        container,
+        ["ccc", "init", "-f"],
+        env={"COCOINDEX_CODE_HOST_CWD": str(fixture_workspace)},
+    )
+    # Record the container's start-time so we can detect a respawn (pid reset).
+    initial_status = docker_exec(container, ["ccc", "daemon", "status"])
+    assert initial_status.returncode == 0
+    assert "Uptime:" in initial_status.stdout
+
+    # Edit global_settings.yml on the host side (bind mount → visible in container).
+    settings_file = fixture_workspace / ".cocoindex_code" / "global_settings.yml"
+    assert settings_file.is_file()
+    content = settings_file.read_text()
+    # Touch mtime by rewriting identical content — still triggers mtime mismatch.
+    time.sleep(1.1)  # ensure mtime actually changes on coarse-grained filesystems
+    settings_file.write_text(content)
+
+    # Next CLI call: the client should detect the mtime mismatch, request
+    # daemon stop, and the entrypoint restart loop should bring a fresh
+    # daemon back up. Container must still be running.
+    after = docker_exec(container, ["ccc", "daemon", "status"])
+    assert after.returncode == 0, after.stderr
+    assert "Uptime:" in after.stdout
+
+    # Container's PID 1 (the entrypoint shell) should still be alive → container not restarted.
+    inspect = subprocess.run(
+        ["docker", "inspect", "-f", "{{.State.Status}}", container],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert inspect.stdout.strip() == "running"
+
+
+def test_first_start_uses_baked_model(container: str) -> None:
+    """Fresh container starts with the pre-baked model — no network download."""
+    # The daemon is already up from the `container` fixture's readiness probe.
+    # Check that the sentence-transformers cache contains the baked model.
+    check = docker_exec(
+        container,
+        ["ls", "/var/cocoindex/cache/sentence-transformers"],
+    )
+    assert check.returncode == 0
+    # At least one model directory should be present from the bake stage.
+    assert check.stdout.strip() != ""
+
+    # Daemon log should not contain a "Downloading" line.
+    log_result = subprocess.run(
+        ["docker", "logs", container],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    # sentence-transformers prints "Downloading" when it fetches a model. A
+    # missing bake would trigger that.
+    assert "Downloading" not in log_result.stdout
+    assert "Downloading" not in log_result.stderr
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="PUID/PGID only meaningful on Linux")
+def test_linux_puid_gives_host_owned_files(
+    docker_image: str, fixture_workspace: Path, tmp_path: Path
+) -> None:
+    """With PUID/PGID set, daemon-written files on the bind mount are owned by the host user."""
+    import os
+    import uuid
+
+    name = f"ccc-e2e-puid-{uuid.uuid4().hex[:8]}"
+    host_ws = str(fixture_workspace)
+    uid = os.getuid()
+    gid = os.getgid()
+    try:
+        subprocess.run(
+            [
+                "docker",
+                "run",
+                "-d",
+                "--rm",
+                "--name",
+                name,
+                "-v",
+                f"{host_ws}:/workspace",
+                "-v",
+                "/var/cocoindex",
+                "-e",
+                f"COCOINDEX_CODE_HOST_PATH_MAPPING=/workspace={host_ws}",
+                "-e",
+                f"PUID={uid}",
+                "-e",
+                f"PGID={gid}",
+                docker_image,
+            ],
+            check=True,
+            capture_output=True,
+        )
+        # Wait for daemon startup (which creates /workspace/.cocoindex_code/global_settings.yml).
+        import time
+
+        settings_file = fixture_workspace / ".cocoindex_code" / "global_settings.yml"
+        deadline = time.monotonic() + 30
+        while time.monotonic() < deadline:
+            if settings_file.is_file():
+                break
+            time.sleep(0.5)
+        else:
+            raise TimeoutError("Daemon did not create global_settings.yml in time")
+
+        st = settings_file.stat()
+        assert st.st_uid == uid, f"Expected uid {uid}, got {st.st_uid}"
+        assert st.st_gid == gid, f"Expected gid {gid}, got {st.st_gid}"
+    finally:
+        subprocess.run(["docker", "rm", "-f", name], capture_output=True, check=False)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="root-in-container UID check is Linux-specific")
+def test_linux_no_puid_runs_as_root(container: str) -> None:
+    """With PUID/PGID unset, the daemon process stays as uid 0 (preserves today's default)."""
+    result = docker_exec(container, ["id", "-u"])
+    assert result.stdout.strip() == "0"
+
+
+def test_docker_compose_smoke(docker_image: str, fixture_workspace: Path, tmp_path: Path) -> None:
+    """`docker compose up -d` + `docker compose exec ccc search` round-trips."""
+    import os
+    import shutil
+
+    compose_src = Path(__file__).resolve().parents[2] / "docker" / "docker-compose.yml"
+    compose_dst = tmp_path / "docker-compose.yml"
+    shutil.copy2(compose_src, compose_dst)
+
+    # The compose file references cocoindex/cocoindex-code:latest (the published
+    # release image). Tag the locally-built pytest image under that name so
+    # `docker compose up` uses our local code instead of pulling from Docker Hub.
+    subprocess.run(
+        ["docker", "tag", docker_image, "cocoindex/cocoindex-code:latest"],
+        check=True,
+    )
+
+    env = dict(os.environ)
+    env["COCOINDEX_HOST_WORKSPACE"] = str(fixture_workspace)
+
+    try:
+        subprocess.run(
+            ["docker", "compose", "-f", str(compose_dst), "up", "-d"],
+            cwd=tmp_path,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+        # Wait for daemon readiness.
+        import time
+
+        deadline = time.monotonic() + 60
+        while time.monotonic() < deadline:
+            check = subprocess.run(
+                [
+                    "docker",
+                    "compose",
+                    "-f",
+                    str(compose_dst),
+                    "exec",
+                    "-T",
+                    "cocoindex-code",
+                    "sh",
+                    "-c",
+                    "test -S /var/run/cocoindex_code/daemon.sock",
+                ],
+                cwd=tmp_path,
+                env=env,
+                capture_output=True,
+                check=False,
+            )
+            if check.returncode == 0:
+                break
+            time.sleep(1)
+        else:
+            raise TimeoutError("Daemon did not become ready via compose")
+
+        # Index, then search.
+        subprocess.run(
+            [
+                "docker",
+                "compose",
+                "-f",
+                str(compose_dst),
+                "exec",
+                "-T",
+                "-e",
+                f"COCOINDEX_CODE_HOST_CWD={fixture_workspace}",
+                "cocoindex-code",
+                "ccc",
+                "init",
+                "-f",
+            ],
+            cwd=tmp_path,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            [
+                "docker",
+                "compose",
+                "-f",
+                str(compose_dst),
+                "exec",
+                "-T",
+                "-e",
+                f"COCOINDEX_CODE_HOST_CWD={fixture_workspace}",
+                "cocoindex-code",
+                "ccc",
+                "index",
+            ],
+            cwd=tmp_path,
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+        search = subprocess.run(
+            [
+                "docker",
+                "compose",
+                "-f",
+                str(compose_dst),
+                "exec",
+                "-T",
+                "-e",
+                f"COCOINDEX_CODE_HOST_CWD={fixture_workspace}",
+                "cocoindex-code",
+                "ccc",
+                "search",
+                "request",
+                "handler",
+            ],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "src/handlers.py" in search.stdout
+    finally:
+        subprocess.run(
+            ["docker", "compose", "-f", str(compose_dst), "down", "-v"],
+            cwd=tmp_path,
+            env=env,
+            capture_output=True,
+            check=False,
+        )

--- a/tests/e2e_docker/test_docker_workspace.py
+++ b/tests/e2e_docker/test_docker_workspace.py
@@ -187,8 +187,10 @@ def test_linux_puid_gives_host_owned_files(
 
     name = f"ccc-e2e-puid-{uuid.uuid4().hex[:8]}"
     host_ws = str(fixture_workspace)
-    uid = os.getuid()
-    gid = os.getgid()
+    # os.getuid/getgid only exist on POSIX; the skipif above already gates
+    # this test to Linux, so getattr lets mypy pass on Windows runners.
+    uid = os.getuid()  # type: ignore[attr-defined,unused-ignore]
+    gid = os.getgid()  # type: ignore[attr-defined,unused-ignore]
     try:
         subprocess.run(
             [

--- a/tests/e2e_docker_fixtures/sample_project/README.md
+++ b/tests/e2e_docker_fixtures/sample_project/README.md
@@ -1,0 +1,7 @@
+# Sample Project
+
+Fixture tree used by Docker E2E tests. Contains a tiny authentication module
+(`src/auth.py`), a request dispatcher (`src/handlers.py`), and a TypeScript
+utility module (`lib/utils.ts`). The content is intentionally generic but
+searchable — tests assert on specific matches like "password verification" or
+"request handler".

--- a/tests/e2e_docker_fixtures/sample_project/lib/utils.ts
+++ b/tests/e2e_docker_fixtures/sample_project/lib/utils.ts
@@ -1,0 +1,13 @@
+// Small utility helpers for the sample project.
+
+export function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+export function chunk<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}

--- a/tests/e2e_docker_fixtures/sample_project/src/auth.py
+++ b/tests/e2e_docker_fixtures/sample_project/src/auth.py
@@ -1,0 +1,21 @@
+"""Authentication helpers used by handlers."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+
+def verify_password(plaintext: str, hashed: str, salt: str) -> bool:
+    """Constant-time check that ``plaintext`` hashes to ``hashed`` with ``salt``.
+
+    Uses SHA-256 over salt || plaintext. Designed for the sample project's
+    login flow — not production-grade.
+    """
+    digest = hashlib.sha256((salt + plaintext).encode("utf-8")).hexdigest()
+    return hmac.compare_digest(digest, hashed)
+
+
+def hash_password(plaintext: str, salt: str) -> str:
+    """Return the SHA-256 digest of ``salt || plaintext`` as hex."""
+    return hashlib.sha256((salt + plaintext).encode("utf-8")).hexdigest()

--- a/tests/e2e_docker_fixtures/sample_project/src/handlers.py
+++ b/tests/e2e_docker_fixtures/sample_project/src/handlers.py
@@ -1,0 +1,37 @@
+"""Simple request handlers for the sample project."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .auth import verify_password
+
+
+@dataclass
+class Request:
+    path: str
+    body: dict[str, Any]
+
+
+class RequestHandler:
+    """Dispatch incoming requests to their handler methods."""
+
+    def __init__(self, users: dict[str, tuple[str, str]]) -> None:
+        self._users = users  # username -> (hashed_password, salt)
+
+    def handle(self, req: Request) -> dict[str, Any]:
+        if req.path == "/login":
+            return self._login(req.body)
+        return {"status": 404}
+
+    def _login(self, body: dict[str, Any]) -> dict[str, Any]:
+        username = body.get("username", "")
+        password = body.get("password", "")
+        entry = self._users.get(username)
+        if entry is None:
+            return {"status": 401}
+        hashed, salt = entry
+        if verify_password(password, hashed, salt):
+            return {"status": 200, "user": username}
+        return {"status": 401}

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -139,3 +139,67 @@ def test_remove_from_gitignore_no_entry(tmp_path: Path) -> None:
     gitignore.write_text(original)
     remove_from_gitignore(tmp_path)
     assert gitignore.read_text() == original
+
+
+# ---------------------------------------------------------------------------
+# COCOINDEX_CODE_HOST_CWD callback
+# ---------------------------------------------------------------------------
+
+
+def test_apply_host_cwd_chdirs_to_mapped_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """When COCOINDEX_CODE_HOST_CWD is set and matches the mapping, chdir to container form."""
+    from cocoindex_code.cli import _apply_host_cwd
+    from cocoindex_code.settings import _reset_host_path_mapping_cache
+
+    container = tmp_path / "workspace"
+    host = tmp_path / "host-home"
+    (container / "proj" / "src").mkdir(parents=True)
+    host.mkdir()
+
+    _reset_host_path_mapping_cache()
+    monkeypatch.setenv("COCOINDEX_CODE_HOST_PATH_MAPPING", f"{container}={host}")
+    monkeypatch.setenv("COCOINDEX_CODE_HOST_CWD", str(host / "proj" / "src"))
+
+    _apply_host_cwd()
+
+    # chdir resolves symlinks; compare resolved forms.
+    assert Path.cwd().resolve() == (container / "proj" / "src").resolve()
+    assert capsys.readouterr().err == ""
+
+    _reset_host_path_mapping_cache()
+
+
+def test_apply_host_cwd_warns_on_invalid_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """An invalid COCOINDEX_CODE_HOST_CWD emits a warning but doesn't abort."""
+    from cocoindex_code.cli import _apply_host_cwd
+
+    original_cwd = Path.cwd()
+    monkeypatch.setenv("COCOINDEX_CODE_HOST_CWD", "/nonexistent/path/xyz")
+    monkeypatch.delenv("COCOINDEX_CODE_HOST_PATH_MAPPING", raising=False)
+
+    _apply_host_cwd()
+
+    captured = capsys.readouterr()
+    assert "COCOINDEX_CODE_HOST_CWD" in captured.err
+    assert "/nonexistent/path/xyz" in captured.err
+    # cwd should be unchanged since chdir failed.
+    assert Path.cwd() == original_cwd
+
+
+def test_apply_host_cwd_noop_when_unset(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """With COCOINDEX_CODE_HOST_CWD unset, the callback is a silent no-op."""
+    from cocoindex_code.cli import _apply_host_cwd
+
+    original_cwd = Path.cwd()
+    monkeypatch.delenv("COCOINDEX_CODE_HOST_CWD", raising=False)
+
+    _apply_host_cwd()
+
+    assert Path.cwd() == original_cwd
+    assert capsys.readouterr().err == ""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -19,3 +19,19 @@ def test_client_connect_refuses_when_no_daemon(
 
     with pytest.raises(ConnectionRefusedError):
         client._raw_connect_and_handshake()
+
+
+def test_is_daemon_supervised_reads_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The supervised branch is controlled by COCOINDEX_CODE_DAEMON_SUPERVISED=1."""
+    monkeypatch.delenv("COCOINDEX_CODE_DAEMON_SUPERVISED", raising=False)
+    assert client._is_daemon_supervised() is False
+
+    monkeypatch.setenv("COCOINDEX_CODE_DAEMON_SUPERVISED", "1")
+    assert client._is_daemon_supervised() is True
+
+    # Anything other than exact "1" is not supervised (avoid accidental truthy values).
+    monkeypatch.setenv("COCOINDEX_CODE_DAEMON_SUPERVISED", "true")
+    assert client._is_daemon_supervised() is False
+
+    monkeypatch.setenv("COCOINDEX_CODE_DAEMON_SUPERVISED", "0")
+    assert client._is_daemon_supervised() is False

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -580,14 +580,24 @@ def test_session_missing_global_settings_early_error() -> None:
 
 
 @pytest.mark.usefixtures("e2e_project_no_global_settings")
-def test_session_daemon_restart_missing_global_settings() -> None:
-    """``ccc daemon restart`` should fail fast with daemon log when global settings are missing."""
-    # `daemon restart` doesn't go through require_project_root, so it hits the
-    # daemon start path where the process dies. Should show the daemon log.
+def test_session_daemon_restart_with_no_global_settings() -> None:
+    """``ccc daemon restart`` without ``global_settings.yml`` starts the daemon in
+    no-settings mode rather than failing hard.
+
+    The daemon comes up, accepts handshakes, but rejects project requests until
+    ``ccc init`` writes the file. The handshake mtime mismatch then drives the
+    restart that loads real settings — here we just verify the restart itself
+    succeeds and the file stays absent (no silent auto-create).
+    """
+    from cocoindex_code.settings import user_settings_path
+
     result = runner.invoke(app, ["daemon", "restart"])
-    assert result.exit_code != 0, f"Expected failure but got: {result.output}"
-    assert "Daemon log:" in result.output
-    assert "User settings not found" in result.output
+    assert result.exit_code == 0, f"Expected success but got: {result.output}"
+    assert "Daemon restarted." in result.output
+
+    # No auto-creation — user still needs to run `ccc init` to pick a model
+    # (and trigger the supervised respawn with real settings).
+    assert not user_settings_path().is_file()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -104,3 +104,85 @@ def test_index_and_search_via_client(e2e_daemon: tuple[str, Path]) -> None:
     assert search_resp.success
     assert len(search_resp.results) > 0
     assert "main.py" in search_resp.results[0].file_path
+
+
+# ---------------------------------------------------------------------------
+# No-settings mode + host_path_mappings wiring
+# ---------------------------------------------------------------------------
+
+
+def test_daemon_starts_in_no_settings_mode_without_global_settings() -> None:
+    """Daemon started against an empty COCOINDEX_CODE_DIR should come up without
+    creating ``global_settings.yml``. The file stays absent; the handshake reports
+    ``mtime=None``. Project requests are rejected with a clear "run `ccc init`" error.
+    """
+    from cocoindex_code.client import stop_daemon as _stop
+    from cocoindex_code.protocol import ProjectStatusRequest, encode_request
+    from cocoindex_code.settings import user_settings_path
+
+    base_dir = Path(tempfile.mkdtemp(prefix="ccc_nosettings_"))
+    old_env = os.environ.get("COCOINDEX_CODE_DIR")
+    os.environ["COCOINDEX_CODE_DIR"] = str(base_dir)
+
+    try:
+        assert not user_settings_path().is_file()
+
+        proc = start_daemon()
+        sock = daemon_socket_path()
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline:
+            if proc.poll() is not None:
+                log = base_dir / "daemon.log"
+                raise RuntimeError(
+                    f"Daemon exited early. Log:\n{log.read_text() if log.exists() else '(none)'}"
+                )
+            if os.path.exists(sock):
+                break
+            time.sleep(0.2)
+        else:
+            raise TimeoutError("Daemon did not start in time")
+
+        # Daemon is up, but global_settings.yml stays absent — no auto-create.
+        assert not user_settings_path().is_file()
+
+        # Handshake works and reports mtime=None (no settings yet).
+        # Use the lower-level raw handshake so we can inspect the response
+        # directly; the high-level client would loop on mtime mismatch.
+        from cocoindex_code.client import _raw_connect_and_handshake
+        from cocoindex_code.protocol import decode_response
+
+        # _raw_connect_and_handshake does its own handshake read — but it also
+        # raises DaemonVersionError when the client-side mtime disagrees. With
+        # the file absent on both sides, mtime=None matches, so handshake OK.
+        conn = _raw_connect_and_handshake()
+        try:
+            # Send a project request — should get an ErrorResponse pointing at
+            # `ccc init`, not a crash.
+            conn.send_bytes(encode_request(ProjectStatusRequest(project_root=str(base_dir))))
+            resp = decode_response(conn.recv_bytes())
+        finally:
+            conn.close()
+
+        from cocoindex_code.protocol import ErrorResponse
+
+        assert isinstance(resp, ErrorResponse)
+        assert "ccc init" in resp.message
+    finally:
+        _stop()
+        if old_env is None:
+            os.environ.pop("COCOINDEX_CODE_DIR", None)
+        else:
+            os.environ["COCOINDEX_CODE_DIR"] = old_env
+
+
+def test_daemon_env_response_includes_host_path_mappings(
+    e2e_daemon: tuple[str, Path],
+) -> None:
+    """``client.daemon_env`` surfaces the parsed COCOINDEX_CODE_HOST_PATH_MAPPING."""
+    _, _project_dir = e2e_daemon
+
+    # The session daemon was started without COCOINDEX_CODE_HOST_PATH_MAPPING,
+    # so this just verifies the field is exposed on the wire and defaults to empty.
+    resp = client.daemon_env()
+    assert hasattr(resp, "host_path_mappings")
+    assert resp.host_path_mappings == []

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -19,12 +19,16 @@ from cocoindex_code.settings import (
     ProjectSettings,
     UserSettings,
     _reset_db_path_mapping_cache,
+    _reset_host_path_mapping_cache,
     default_project_settings,
     default_user_settings,
     find_parent_with_marker,
     find_project_root,
+    format_path_for_display,
+    get_host_path_mappings,
     load_project_settings,
     load_user_settings,
+    normalize_input_path,
     resolve_db_dir,
     save_project_settings,
     save_user_settings,
@@ -379,3 +383,139 @@ def test_save_initial_user_settings_model_with_colon() -> None:
     loaded = load_user_settings()
     assert loaded.embedding.provider == "litellm"
     assert loaded.embedding.model == "ollama_chat/llama3:latest"
+
+
+# ---------------------------------------------------------------------------
+# Host path mapping (COCOINDEX_CODE_HOST_PATH_MAPPING)
+# ---------------------------------------------------------------------------
+
+
+class TestHostPathMapping:
+    """Tests for format_path_for_display / normalize_input_path and the shared parser."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_cache(self, monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+        _reset_host_path_mapping_cache()
+        monkeypatch.delenv("COCOINDEX_CODE_HOST_PATH_MAPPING", raising=False)
+        yield
+        _reset_host_path_mapping_cache()
+
+    def test_translates_display(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        container = tmp_path / "workspace"
+        host = tmp_path / "alice"
+        container.mkdir()
+        host.mkdir()
+        monkeypatch.setenv("COCOINDEX_CODE_HOST_PATH_MAPPING", f"{container}={host}")
+        assert format_path_for_display(container / "proj" / "app.py") == str(
+            host / "proj" / "app.py"
+        )
+
+    def test_translates_input(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        container = tmp_path / "workspace"
+        host = tmp_path / "alice"
+        container.mkdir()
+        host.mkdir()
+        monkeypatch.setenv("COCOINDEX_CODE_HOST_PATH_MAPPING", f"{container}={host}")
+        assert normalize_input_path(host / "proj") == str(container / "proj")
+
+    def test_unmatched_absolute_passes_through(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        container = tmp_path / "workspace"
+        host = tmp_path / "alice"
+        container.mkdir()
+        host.mkdir()
+        monkeypatch.setenv("COCOINDEX_CODE_HOST_PATH_MAPPING", f"{container}={host}")
+        unrelated = "/etc/hosts"
+        assert format_path_for_display(unrelated) == unrelated
+        assert normalize_input_path(unrelated) == unrelated
+
+    def test_relative_passes_through(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        container = tmp_path / "workspace"
+        host = tmp_path / "alice"
+        container.mkdir()
+        host.mkdir()
+        monkeypatch.setenv("COCOINDEX_CODE_HOST_PATH_MAPPING", f"{container}={host}")
+        assert format_path_for_display("src/app.py") == "src/app.py"
+        assert normalize_input_path("src/app.py") == "src/app.py"
+
+    def test_first_match_wins(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        ws = tmp_path / "workspace"
+        shared = ws / "shared"
+        host_ws = tmp_path / "alice"
+        host_shared = tmp_path / "mnt-shared"
+        ws.mkdir()
+        shared.mkdir(parents=True)
+        host_ws.mkdir()
+        host_shared.mkdir()
+        monkeypatch.setenv(
+            "COCOINDEX_CODE_HOST_PATH_MAPPING",
+            f"{ws}={host_ws},{shared}={host_shared}",
+        )
+        # Path under shared — first mapping wins, not the more-specific one.
+        assert format_path_for_display(shared / "docs" / "x") == str(
+            host_ws / "shared" / "docs" / "x"
+        )
+
+    def test_env_unset_is_noop(self) -> None:
+        # Fixture already clears env var.
+        assert format_path_for_display("/workspace/x") == "/workspace/x"
+        assert normalize_input_path("/workspace/x") == "/workspace/x"
+        assert get_host_path_mappings() == []
+
+    def test_invalid_env_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("COCOINDEX_CODE_HOST_PATH_MAPPING", "relative=/abs")
+        with pytest.raises(ValueError, match="source path must be absolute"):
+            get_host_path_mappings()
+
+
+# ---------------------------------------------------------------------------
+# find_parent_with_marker — global-only should not match
+# ---------------------------------------------------------------------------
+
+
+def test_find_parent_with_marker_skips_global_only(tmp_path: Path) -> None:
+    """A workspace-root ``.cocoindex_code/`` holding only ``global_settings.yml``
+    should NOT trigger the parent-marker check (it's not a project).
+    """
+    ws = tmp_path / "ws"
+    (ws / ".cocoindex_code").mkdir(parents=True)
+    (ws / ".cocoindex_code" / "global_settings.yml").write_text("embedding: {model: x}\n")
+    subdir = ws / "myproject"
+    subdir.mkdir()
+    assert find_parent_with_marker(subdir) is None
+
+
+def test_find_parent_with_marker_detects_project_settings(tmp_path: Path) -> None:
+    """``.cocoindex_code/settings.yml`` at a parent is a real project marker."""
+    repo = tmp_path / "repo"
+    (repo / ".cocoindex_code").mkdir(parents=True)
+    (repo / ".cocoindex_code" / "settings.yml").write_text("include_patterns: []\n")
+    subdir = repo / "src"
+    subdir.mkdir()
+    assert find_parent_with_marker(subdir) == repo
+
+
+# ---------------------------------------------------------------------------
+# daemon_runtime_dir
+# ---------------------------------------------------------------------------
+
+
+def test_daemon_runtime_dir_uses_env_var(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from cocoindex_code._daemon_paths import daemon_runtime_dir
+
+    target = tmp_path / "runtime"
+    monkeypatch.setenv("COCOINDEX_CODE_RUNTIME_DIR", str(target))
+    assert daemon_runtime_dir() == target
+
+
+def test_daemon_runtime_dir_falls_back_to_user_settings_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When COCOINDEX_CODE_RUNTIME_DIR is unset, falls back to user_settings_dir()."""
+    from cocoindex_code._daemon_paths import daemon_runtime_dir
+
+    settings_dir = tmp_path / "settings"
+    monkeypatch.delenv("COCOINDEX_CODE_RUNTIME_DIR", raising=False)
+    monkeypatch.setenv("COCOINDEX_CODE_DIR", str(settings_dir))
+    assert daemon_runtime_dir() == settings_dir


### PR DESCRIPTION
Closes #128.

## Summary

- Reshape the Docker experience around a single bind mount + single named volume. Global settings live on the host at `$HOME/.cocoindex_code/global_settings.yml` (visible, editable, no `docker exec cat` dance). Index databases and the pre-baked model cache share one `cocoindex-data` volume; daemon runtime state (`daemon.sock`/`daemon.pid`/`daemon.log`) stays on the container's native FS.
- Introduce a bidirectional host/container path translator (`COCOINDEX_CODE_HOST_PATH_MAPPING`) and a host-pwd forwarding env var (`COCOINDEX_CODE_HOST_CWD`) so CLI output and MCP results show host-side paths and `cd`+`ccc` works from any project under the mounted workspace.
- Make settings-change restart safe in Docker: the daemon tolerates a missing `global_settings.yml` (starts in "no-settings" mode), the entrypoint runs a restart loop with signal forwarding, and the client branches on a new `COCOINDEX_CODE_DAEMON_SUPERVISED` env var — `stop_daemon()` then wait, no `start_daemon()` race. Non-Docker behavior unchanged.
- Add `PUID`/`PGID` entrypoint pattern with `gosu` so files written to the bind mount on Linux are owned by the host user, not root. `docker/docker-compose.yml` wires this as a one-command quickstart.
- CI release workflow now publishes the image to both Docker Hub (primary, `cocoindex/cocoindex-code`) and GHCR (mirror, `ghcr.io/cocoindex-io/cocoindex-code`). GHCR swap is documented as a one-line README change.

## Test plan

- [x] `uv run mypy .` — no issues in 35 source files
- [x] `uv run pytest tests/` — 147 passed, 8 deselected by `docker_e2e` marker
- [x] `uv run pytest -m docker_e2e` — 6 passed, 2 Linux-only PUID tests skipped on macOS (covers index+search, host-cwd forwarding valid/invalid, baked-model-no-redownload, settings-change supervised restart, `docker compose up` smoke)
- [ ] CI: default matrix + the new publishing workflow step runs on release (Docker Hub + GHCR tokens still need to be configured in repo settings before the first release — see spec for the one-time setup checklist)

Pre-merge setup owners need to do:
- Create `docker-hub` GitHub environment with `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets (workflow already references it)
- Ensure repo Actions permissions allow `GITHUB_TOKEN` to write packages (for GHCR push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
