### PR TITLE
feat(ci): build multi-arch Docker image (linux/amd64 + linux/arm64)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,6 +126,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # QEMU lets buildx cross-compile linux/arm64 on the x86_64 runner.
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -172,6 +178,9 @@ jobs:
           context: .
           file: docker/Dockerfile
           push: true
+          # Native amd64 for Linux servers + Intel Macs; arm64 (cross-compiled
+          # via QEMU) for Apple Silicon Macs and arm64 Linux hosts.
+          platforms: linux/amd64,linux/arm64
           # Install cocoindex-code from the checked-out source tree, not PyPI.
           # Avoids a race where a just-published version hasn't propagated to
           # PyPI's CDN yet (which happened on v0.2.24 release), and ensures


### PR DESCRIPTION
Follow-up to #135 and #136.

## Summary
- Add QEMU setup and `platforms: linux/amd64,linux/arm64` to the `publish-docker` job. Apple Silicon Macs and arm64 Linux hosts (e.g. AWS Graviton) now get a native image through manifest selection, instead of running the amd64 image under Docker Desktop's emulation — which is especially slow for this image because of `torch` + sentence-transformers at runtime.
- amd64 pulls are unchanged.

## Tradeoff
arm64 is cross-compiled via QEMU on the x86_64 runner, so release builds take noticeably longer (the torch install in stage 1 and the model bake in stage 2 both run emulated). Acceptable for our release cadence; if it becomes painful we can split into an amd64/arm64 matrix using GitHub's native `ubuntu-24.04-arm` runner + `docker/metadata-action` manifest merge.

## Test plan
- Trigger the workflow manually (`workflow_dispatch` with `test_docker=true`) after this lands to verify both platforms build successfully. The `:test` tag gets a multi-arch manifest; `docker buildx imagetools inspect cocoindex/cocoindex-code:test` should show both platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
