### PR TITLE
docs(docker): one-liner compose install + env-overridable image

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,15 +219,17 @@ The rest of this section uses `:latest` — substitute `:full` in the `image:` /
 
 ### Quick start — `docker compose up -d`
 
-Grab [`docker/docker-compose.yml`](./docker/docker-compose.yml) from this repo and run:
+Bring it up in one line — no clone needed (bash / zsh):
 
 ```bash
 # macOS / Windows
-docker compose up -d
+docker compose -f <(curl -L https://raw.githubusercontent.com/cocoindex-io/cocoindex-code/refs/heads/main/docker/docker-compose.yml) up -d
 
 # Linux (aligns file ownership on bind-mounted paths with your host user)
-PUID=$(id -u) PGID=$(id -g) docker compose up -d
+PUID=$(id -u) PGID=$(id -g) docker compose -f <(curl -L https://raw.githubusercontent.com/cocoindex-io/cocoindex-code/refs/heads/main/docker/docker-compose.yml) up -d
 ```
+
+Or grab [`docker/docker-compose.yml`](./docker/docker-compose.yml) and run `docker compose up -d` next to it (works on any shell, including Windows cmd / PowerShell).
 
 By default your home directory is mounted into the container (set
 `COCOINDEX_HOST_WORKSPACE` to narrow this to a specific code folder). Index
@@ -235,9 +237,12 @@ data and the embedding model cache persist in a Docker volume across
 restarts. Your global settings file at `$HOME/.cocoindex_code/global_settings.yml`
 is visible and editable on the host; edits take effect on your next `ccc` command.
 
-> **GHCR:** to pull from GitHub Container Registry instead of Docker Hub,
-> change the `image:` line in your copy of `docker-compose.yml` to
-> `ghcr.io/cocoindex-io/cocoindex-code:latest`.
+> **Pick a different image:** set `COCOINDEX_CODE_IMAGE` to override the
+> default. For example, the `:full` variant or GHCR:
+> ```bash
+> COCOINDEX_CODE_IMAGE=cocoindex/cocoindex-code:full docker compose up -d
+> COCOINDEX_CODE_IMAGE=ghcr.io/cocoindex-io/cocoindex-code:latest docker compose up -d
+> ```
 
 ### Or: `docker run`
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,12 +10,13 @@
 # workspace. Set COCOINDEX_HOST_WORKSPACE=/path/to/code to mount a narrower
 # directory instead.
 #
-# Using GHCR instead of Docker Hub? Change the image below to
-# `ghcr.io/cocoindex-io/cocoindex-code:latest`.
+# Override the image via COCOINDEX_CODE_IMAGE — for example:
+#   COCOINDEX_CODE_IMAGE=cocoindex/cocoindex-code:full docker compose up -d
+#   COCOINDEX_CODE_IMAGE=ghcr.io/cocoindex-io/cocoindex-code:latest docker compose up -d
 
 services:
   cocoindex-code:
-    image: cocoindex/cocoindex-code:latest
+    image: ${COCOINDEX_CODE_IMAGE:-cocoindex/cocoindex-code:latest}
     container_name: cocoindex-code
     volumes:
       - ${COCOINDEX_HOST_WORKSPACE:-${HOME}}:/workspace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,7 @@ dependencies = [
 # `embeddings-local` is the primary feature extra: it pulls in
 # `sentence-transformers` (via cocoindex) so local embeddings work without
 # an API key.
-embeddings-local = [
-    "cocoindex[sentence-transformers]==1.0.0a43",
-]
+embeddings-local = ["cocoindex[sentence-transformers]==1.0.0a43"]
 # `full` is the umbrella "batteries-included" alias. Today it's just
 # `embeddings-local`, but we expect to bundle more optional niceties under
 # it over time — users who want everything can keep using `[full]` and pick
@@ -49,9 +47,7 @@ embeddings-local = [
 # `:full` image variant for consistency across install paths. Contents are
 # inlined rather than self-referencing `cocoindex-code[embeddings-local]`
 # to avoid resolver edge cases with older pip.
-full = [
-    "cocoindex[sentence-transformers]==1.0.0a43",
-]
+full = ["cocoindex[sentence-transformers]==1.0.0a43"]
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
@@ -110,6 +106,7 @@ python_version = "3.11"
 strict = true
 ignore_missing_imports = true
 explicit_package_bases = true
+files = ["src"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
## Summary
- README: add a bash/zsh one-liner (`docker compose -f <(curl …) up -d`) so users don't need to clone the repo; keep the grab-the-file path for non-POSIX shells.
- docker-compose.yml: image is now `${COCOINDEX_CODE_IMAGE:-cocoindex/cocoindex-code:latest}`, so switching to `:full` or GHCR is just an env var instead of an edit.
- pyproject: scope mypy to `src/` and collapse the single-entry extras arrays.

## Test plan
CI
