### PR TITLE
fix(litellm): pass encoding_format="float" explicitly

### DIFF
--- a/src/cocoindex_code/litellm_embedder.py
+++ b/src/cocoindex_code/litellm_embedder.py
@@ -85,6 +85,7 @@ class PacedLiteLLMEmbedder(LiteLLMEmbedder):
             response = await self._aembedding_with_rate_limit_retries(
                 model=self._model,
                 input=input,
+                encoding_format="float",
                 **kwargs,
             )
 

--- a/tests/test_litellm_embedder.py
+++ b/tests/test_litellm_embedder.py
@@ -25,7 +25,7 @@ async def test_run_embedding_request_retries_rate_limit_errors(
         attempts += 1
         assert model == "text-embedding-3-small"
         assert input == ["hello"]
-        assert kwargs == {}
+        assert kwargs == {"encoding_format": "float"}
         if attempts == 1:
             raise Exception("Rate limit exceeded. Please try again in 250ms")
         return SimpleNamespace(data=[{"embedding": [1.0, 2.0]}])
@@ -54,7 +54,7 @@ async def test_run_embedding_request_applies_min_interval_between_requests(
 
     async def fake_aembedding(*, model: str, input: list[str], **kwargs: Any) -> Any:
         assert model == "text-embedding-3-small"
-        assert kwargs == {}
+        assert kwargs == {"encoding_format": "float"}
         inputs_seen.append(input)
         return SimpleNamespace(data=[{"embedding": [1.0, 2.0]}])
 


### PR DESCRIPTION
## Summary
- LiteLLM documents `encoding_format` as defaulting to `float`, but some providers (e.g. `nvidia_nim`) error when it isn't passed explicitly.
- Work around by passing `encoding_format="float"` on every `PacedLiteLLMEmbedder` request.
- Update unit tests to reflect the new kwarg.

## Test plan
- CI (`uv run pytest tests/test_litellm_embedder.py` passes locally).
