### PR TITLE
chore: drop cocoindex prerelease install flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ pipx upgrade cocoindex-code                  # upgrade
 
 Using [uv](https://docs.astral.sh/uv/getting-started/installation/):
 ```bash
-uv tool install --upgrade 'cocoindex-code[full]' --prerelease explicit --with "cocoindex>=1.0.0a24"
+uv tool install --upgrade 'cocoindex-code[full]'
 ```
 
 Two install styles — they mirror the Docker image variants of the same names:
@@ -683,7 +683,7 @@ pipx upgrade cocoindex-code       # upgrade
 
 Using uv (install or upgrade):
 ```bash
-uv tool install --upgrade cocoindex-code --prerelease explicit --with "cocoindex>=1.0.0a24"
+uv tool install --upgrade cocoindex-code
 ```
 
 ## Legacy: Environment Variables

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,7 @@ RUN pip install --quiet uv
 # this layer on upgrade.
 ARG CCC_VARIANT=slim
 RUN if [ "$CCC_VARIANT" = "full" ]; then \
-        uv pip install --system --prerelease=allow sentence-transformers; \
+        uv pip install --system sentence-transformers; \
     fi
 
 ENV HF_HOME=/var/cocoindex/cache/huggingface \
@@ -101,6 +101,4 @@ RUN --mount=type=bind,source=.,target=/ccc-src,rw=true \
             CCC_INSTALL_SPEC="cocoindex-code"; \
         fi; \
     fi; \
-    uv pip install --system --prerelease=allow \
-        "cocoindex>=1.0.0a33" \
-        "${CCC_INSTALL_SPEC}"
+    uv pip install --system "${CCC_INSTALL_SPEC}"


### PR DESCRIPTION
## Summary
- `cocoindex` 1.0.0 is stable, so install docs no longer need `--prerelease` or explicit prerelease version pins.
- Simplify the `uv tool install` commands in the README (Get Started + Troubleshooting).
- Drop `--prerelease=allow` from the Dockerfile and remove the redundant `cocoindex>=1.0.0a33` build-time pin — pyproject.toml already constrains `cocoindex[litellm]>=1.0.0,<1.1.0`.

## Test plan
CI
