### PR TITLE
refactor: drop unused shared.embedder global

### DIFF
--- a/src/cocoindex_code/shared.py
+++ b/src/cocoindex_code/shared.py
@@ -35,10 +35,7 @@ EMBEDDER = coco.ContextKey[Embedder]("embedder", detect_change=True)
 SQLITE_DB = coco.ContextKey[sqlite.ManagedConnection]("index_db")
 CODEBASE_DIR = coco.ContextKey[pathlib.Path]("codebase")
 
-# Module-level variable — set by daemon at startup (needed for CodeChunk annotation).
-embedder: Embedder | None = None
-
-# Query prompt name — set alongside embedder by create_embedder().
+# Query prompt name — set by create_embedder().
 query_prompt_name: str | None = None
 
 
@@ -80,9 +77,9 @@ async def check_embedding(embedder: Embedder) -> EmbeddingCheckResult:
 def create_embedder(settings: EmbeddingSettings) -> Embedder:
     """Create and return an embedder instance based on settings.
 
-    Also sets the module-level ``embedder`` and ``query_prompt_name`` variables.
+    Also sets the module-level ``query_prompt_name`` variable.
     """
-    global embedder, query_prompt_name
+    global query_prompt_name
 
     if settings.provider == "sentence-transformers":
         from cocoindex.ops.sentence_transformers import SentenceTransformerEmbedder
@@ -118,7 +115,6 @@ def create_embedder(settings: EmbeddingSettings) -> Embedder:
             min_interval_ms,
         )
 
-    embedder = instance
     return instance
 
 

--- a/tests/test_chunker_registry.py
+++ b/tests/test_chunker_registry.py
@@ -12,12 +12,10 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
-import pytest
 from cocoindex.connectors import sqlite as coco_sqlite
 from cocoindex.resources.schema import VectorSchema
 from example_toml_chunker import toml_chunker
 
-import cocoindex_code.shared as _shared
 from cocoindex_code.chunking import CHUNKER_REGISTRY, Chunk, TextPosition
 from cocoindex_code.project import Project
 from cocoindex_code.settings import ProjectSettings
@@ -44,14 +42,11 @@ class _StubEmbedder:
 
 async def _index_project(
     project_root: Path,
-    monkeypatch: pytest.MonkeyPatch,
     **create_kwargs: Any,
 ) -> Project:
     """Create a Project and run a full index pass."""
     settings = ProjectSettings(include_patterns=["**/*.*"], exclude_patterns=["**/.cocoindex_code"])
     stub = _StubEmbedder()
-    # shared.embedder is read by CodeChunk.embedding at schema resolution time.
-    monkeypatch.setattr(_shared, "embedder", stub)
     from cocoindex_code.settings import save_project_settings
 
     save_project_settings(project_root, settings)
@@ -104,25 +99,23 @@ flag = true
 # ---------------------------------------------------------------------------
 
 
-async def test_default_registry_is_empty(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_default_registry_is_empty(tmp_path: Path) -> None:
     """CHUNKER_REGISTRY is an empty dict when no registry is passed."""
     (tmp_path / ".git").mkdir()
     (tmp_path / "hello.py").write_text("x = 1\n")
 
-    project = await _index_project(tmp_path, monkeypatch)
+    project = await _index_project(tmp_path)
     registry = project.env.get_context(CHUNKER_REGISTRY)
     assert isinstance(registry, dict)
     assert registry == {}
 
 
-async def test_unregistered_suffix_uses_splitter(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_unregistered_suffix_uses_splitter(tmp_path: Path) -> None:
     """Files with no registered chunker are processed by RecursiveSplitter."""
     (tmp_path / ".git").mkdir()
     (tmp_path / "sample.py").write_text("def foo():\n    return 1\n")
 
-    await _index_project(tmp_path, monkeypatch)
+    await _index_project(tmp_path)
     chunks = _query_chunks(tmp_path)
 
     assert len(chunks) >= 1
@@ -130,14 +123,12 @@ async def test_unregistered_suffix_uses_splitter(
     assert any("foo" in c["content"] for c in chunks)
 
 
-async def test_registered_chunker_is_called(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_registered_chunker_is_called(tmp_path: Path) -> None:
     """A registered ChunkerFn splits files and may override the language."""
     (tmp_path / ".git").mkdir()
     (tmp_path / "config.toml").write_text(_TOML_CONTENT)
 
-    await _index_project(tmp_path, monkeypatch, chunker_registry={".toml": toml_chunker})
+    await _index_project(tmp_path, chunker_registry={".toml": toml_chunker})
     chunks = _query_chunks(tmp_path)
 
     assert len(chunks) == 2
@@ -147,9 +138,7 @@ async def test_registered_chunker_is_called(
     assert all(c["language"] == "toml" for c in chunks)
 
 
-async def test_chunker_language_none_preserves_detected(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_chunker_language_none_preserves_detected(tmp_path: Path) -> None:
     """When ChunkerFn returns language=None, detect_code_language() is used."""
 
     def _passthrough_chunker(path: Path, content: str) -> tuple[str | None, list[Chunk]]:
@@ -159,21 +148,19 @@ async def test_chunker_language_none_preserves_detected(
     (tmp_path / ".git").mkdir()
     (tmp_path / "script.py").write_text("x = 1\n")
 
-    await _index_project(tmp_path, monkeypatch, chunker_registry={".py": _passthrough_chunker})
+    await _index_project(tmp_path, chunker_registry={".py": _passthrough_chunker})
     chunks = _query_chunks(tmp_path)
 
     assert all(c["language"] == "python" for c in chunks)
 
 
-async def test_registry_does_not_affect_other_suffixes(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+async def test_registry_does_not_affect_other_suffixes(tmp_path: Path) -> None:
     """Registering a chunker for .toml does not affect .py files."""
     (tmp_path / ".git").mkdir()
     (tmp_path / "config.toml").write_text(_TOML_CONTENT)
     (tmp_path / "code.py").write_text("def bar():\n    pass\n")
 
-    await _index_project(tmp_path, monkeypatch, chunker_registry={".toml": toml_chunker})
+    await _index_project(tmp_path, chunker_registry={".toml": toml_chunker})
     chunks = _query_chunks(tmp_path)
 
     toml_chunks = [c for c in chunks if c["language"] == "toml"]

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -56,14 +56,6 @@ def calculate_fibonacci(n: int) -> int:
 def daemon_sock() -> Iterator[str]:
     """Start a daemon once per session and return the socket path."""
     import cocoindex_code.daemon as dm
-    from cocoindex_code.shared import create_embedder
-    from cocoindex_code.shared import embedder as shared_emb
-
-    emb = (
-        shared_emb
-        if shared_emb is not None
-        else create_embedder(make_test_user_settings().embedding)
-    )
 
     # Use a short path to stay within AF_UNIX limit
     user_dir = Path(tempfile.mkdtemp(prefix="ccc_d_"))
@@ -74,10 +66,6 @@ def daemon_sock() -> Iterator[str]:
     # stop_daemon() in other fixtures to read the wrong PID file (pytest's own PID).
     old_env = os.environ.get("COCOINDEX_CODE_DIR")
     os.environ["COCOINDEX_CODE_DIR"] = str(user_dir)
-
-    # Patch create_embedder to reuse the already-loaded embedder (performance)
-    _orig_create_embedder = dm.create_embedder
-    dm.create_embedder = lambda settings: emb
 
     save_user_settings(make_test_user_settings())
 
@@ -108,8 +96,6 @@ def daemon_sock() -> Iterator[str]:
         pass
     thread.join(timeout=5)
 
-    # Restore patches and env var
-    dm.create_embedder = _orig_create_embedder
     if old_env is None:
         os.environ.pop("COCOINDEX_CODE_DIR", None)
     else:


### PR DESCRIPTION
## Summary
- Drop the unused `shared.embedder` module-level global. It was set by `create_embedder()` but never read from production code — the embedder flows through the `EMBEDDER` `ContextKey` via `context.provide` / `use_context`.
- Simplify `tests/test_daemon.py`'s `daemon_sock` fixture: the pre-load + `dm.create_embedder` monkeypatch was only a win as a cross-module cache via the now-dead global. The session-scoped fixture loads once either way, and `run_daemon()` is now exercised on its real embedder path.
- Remove the stale `monkeypatch.setattr(_shared, "embedder", stub)` in `tests/test_chunker_registry.py`. `CodeChunk.embedding` is annotated with the `EMBEDDER` ContextKey (not the global), and the stub is already wired through `Project.create(..., stub, ...)`.

## Test plan
- `uv run mypy .` — passes.
- `uv run pytest tests/test_daemon.py tests/test_chunker_registry.py` — passes locally.
- CI covers the rest.
