### PR TITLE
fix(litellm): skip encoding_format="float" for voyage/bedrock

### DIFF
--- a/src/cocoindex_code/litellm_embedder.py
+++ b/src/cocoindex_code/litellm_embedder.py
@@ -13,8 +13,6 @@ import numpy as np
 from cocoindex.ops.litellm import LiteLLMEmbedder, litellm
 from numpy.typing import NDArray
 
-litellm.drop_params = True
-
 logger = logging.getLogger(__name__)
 
 _RATE_LIMIT_DELAY_RE = re.compile(r"Please try again in ([0-9.]+)(ms|s)", re.IGNORECASE)
@@ -84,10 +82,12 @@ class PacedLiteLLMEmbedder(LiteLLMEmbedder):
             if self._next_request_at > now:
                 await asyncio.sleep(self._next_request_at - now)
 
+            if not self._model.startswith(("voyage/", "bedrock/")):
+                kwargs["encoding_format"] = "float"
+                kwargs["drop_params"] = True
             response = await self._aembedding_with_rate_limit_retries(
                 model=self._model,
                 input=input,
-                encoding_format="float",
                 **kwargs,
             )
 

--- a/tests/test_litellm_embedder.py
+++ b/tests/test_litellm_embedder.py
@@ -25,7 +25,7 @@ async def test_run_embedding_request_retries_rate_limit_errors(
         attempts += 1
         assert model == "text-embedding-3-small"
         assert input == ["hello"]
-        assert kwargs == {"encoding_format": "float"}
+        assert kwargs == {"encoding_format": "float", "drop_params": True}
         if attempts == 1:
             raise Exception("Rate limit exceeded. Please try again in 250ms")
         return SimpleNamespace(data=[{"embedding": [1.0, 2.0]}])
@@ -54,7 +54,7 @@ async def test_run_embedding_request_applies_min_interval_between_requests(
 
     async def fake_aembedding(*, model: str, input: list[str], **kwargs: Any) -> Any:
         assert model == "text-embedding-3-small"
-        assert kwargs == {"encoding_format": "float"}
+        assert kwargs == {"encoding_format": "float", "drop_params": True}
         inputs_seen.append(input)
         return SimpleNamespace(data=[{"embedding": [1.0, 2.0]}])
 
@@ -70,3 +70,27 @@ async def test_run_embedding_request_applies_min_interval_between_requests(
     assert inputs_seen == [["second"]]
     assert len(sleep_calls) == 1
     assert sleep_calls[0] == pytest.approx(0.3)
+
+
+@pytest.mark.parametrize(
+    "model_name", ["voyage/voyage-code-3", "bedrock/amazon.titan-embed-text-v2:0"]
+)
+@pytest.mark.asyncio
+async def test_run_embedding_request_omits_encoding_format_for_native_providers(
+    monkeypatch: pytest.MonkeyPatch, model_name: str
+) -> None:
+    seen_kwargs: dict[str, Any] = {}
+
+    async def fake_aembedding(*, model: str, input: list[str], **kwargs: Any) -> Any:
+        assert model == model_name
+        assert input == ["hello"]
+        seen_kwargs.update(kwargs)
+        return SimpleNamespace(data=[{"embedding": [1.0, 2.0]}])
+
+    monkeypatch.setattr("cocoindex_code.litellm_embedder.litellm.aembedding", fake_aembedding)
+
+    embedder = PacedLiteLLMEmbedder(model_name)
+    await embedder.run_embedding_request(input=["hello"])
+
+    assert "encoding_format" not in seen_kwargs
+    assert "drop_params" not in seen_kwargs


### PR DESCRIPTION
## Summary
- Only inject `encoding_format="float"` and `drop_params=True` for providers that accept the float hint; voyage/ and bedrock/ models keep their native defaults (voyage requires base64).
- Drops the global `litellm.drop_params = True` side effect; the flag is now passed per-call alongside the encoding hint.
- Adds a parametrized regression test covering voyage and bedrock model prefixes.

Fixes #148

## Test plan
- `uv run pytest tests/test_litellm_embedder.py`
- CI
