### PR TITLE
feat: ship as a Claude Code plugin marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,28 @@
+{
+  "name": "cocoindex-code",
+  "version": "1.0.0",
+  "description": "AST-based semantic code search for Claude Code, Cursor, and any skill-compatible coding agent — install in one command.",
+  "owner": {
+    "name": "CocoIndex",
+    "email": "hi@cocoindex.io"
+  },
+  "plugins": [
+    {
+      "name": "cocoindex-code",
+      "source": "./",
+      "description": "Semantic code search skill — wraps the `ccc` CLI to give coding agents AST-aware search over the current codebase.",
+      "category": "development",
+      "tags": [
+        "semantic-search",
+        "code-search",
+        "ast",
+        "indexing",
+        "rag",
+        "skill"
+      ],
+      "homepage": "https://github.com/cocoindex-io/cocoindex-code",
+      "repository": "https://github.com/cocoindex-io/cocoindex-code",
+      "license": "Apache-2.0"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,21 @@
+{
+  "name": "cocoindex-code",
+  "version": "1.0.0",
+  "description": "AST-based semantic code search via the ccc CLI. Bundles the ccc skill so coding agents handle init, indexing, and search automatically.",
+  "author": {
+    "name": "CocoIndex",
+    "email": "hi@cocoindex.io"
+  },
+  "homepage": "https://github.com/cocoindex-io/cocoindex-code",
+  "repository": "https://github.com/cocoindex-io/cocoindex-code",
+  "license": "Apache-2.0",
+  "keywords": [
+    "semantic-search",
+    "code-search",
+    "ast",
+    "rag",
+    "indexing",
+    "claude-code",
+    "skill"
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ The agent uses semantic search automatically when it would be helpful. You can a
 
 Works with [Claude Code](https://docs.anthropic.com/en/docs/claude-code) and other skill-compatible agents.
 
+#### Claude Code plugin marketplace
+
+For Claude Code users, this repository is also a [plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces). Install the skill from inside Claude Code with:
+
+```text
+/plugin marketplace add cocoindex-io/cocoindex-code
+/plugin install cocoindex-code@cocoindex-code
+```
+
+This bundles the same `ccc` skill, with version pinning and `/plugin marketplace update` for updates.
+
 ### MCP Server
 
 Alternatively, use `ccc mcp` to run as an MCP server:


### PR DESCRIPTION
## Summary

- Adds `.claude-plugin/marketplace.json` and `.claude-plugin/plugin.json` so this repo doubles as a [Claude Code plugin marketplace](https://code.claude.com/docs/en/plugin-marketplaces).
- Users can install the existing `ccc` skill from inside Claude Code with two commands, alongside the existing `npx skills add` flow.
- Zero file moves — `skills/ccc/SKILL.md` is auto-discovered as the plugin's skill; the `npx skills add cocoindex-io/cocoindex-code` workflow keeps working exactly as before.

## Why

Coding agents that natively understand Claude Code plugins (Claude Code itself, and any forks/clients that adopt the schema) get a one-step install path with version pinning, automatic updates via `/plugin marketplace update`, and discoverability via `/plugin install`. This complements the existing skill / MCP install paths rather than replacing either.

## What changed

| File | Change |
|---|---|
| `.claude-plugin/marketplace.json` | new — single-plugin marketplace pointing at the repo root |
| `.claude-plugin/plugin.json` | new — plugin manifest (name, version, description, author, license, keywords) |
| `README.md` | +11 lines — adds a `#### Claude Code plugin marketplace` subsection under existing "Skill (Recommended)" |

## How to verify locally

```bash
# from any Claude Code session
/plugin marketplace add cocoindex-io/cocoindex-code
/plugin install cocoindex-code@cocoindex-code
# then in a project
ccc init && ccc index
```

The skill becomes available as `/cocoindex-code:ccc` (plugin-namespaced) and the agent's automatic search behavior works as documented in `skills/ccc/SKILL.md`.

## Compatibility

- ✅ Existing `npx skills add cocoindex-io/cocoindex-code` flow unaffected
- ✅ MCP server flow (`ccc mcp`) unaffected
- ✅ No changes to source code, package, CLI, or tests
- ✅ Apache-2.0 license and authorship metadata preserved in plugin manifest

## Open questions for maintainers

- Happy to adjust the marketplace `name` / plugin `name` if you'd prefer a different identifier (e.g. `ccc` vs `cocoindex-code`).
- `email` field in `owner` is set to `hi@cocoindex.io` — drop or replace if not the right contact.
- `version` pinned to `1.0.0`; if you'd rather rely on git-SHA-based versioning, both `version` fields can be omitted (per [docs](https://code.claude.com/docs/en/plugin-marketplaces#version-resolution-and-release-channels)).

Drafted as a draft PR — happy to iterate on naming, copy, and metadata before merge.