### PR TITLE
docs(skills/ccc): document `ccc describe` and `ccc guide`

### DIFF
--- a/skills/ccc/SKILL.md
+++ b/skills/ccc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ccc
-description: "This skill should be used when code search is needed (whether explicitly requested or as part of completing a task), when indexing the codebase after changes, or when the user asks about ccc, cocoindex-code, or the codebase index. Trigger phrases include 'search the codebase', 'find code related to', 'update the index', 'ccc', 'cocoindex-code'."
+description: "This skill should be used when code search, file/directory summary lookup, or concept-guide lookup is needed (whether explicitly requested or as part of completing a task), when indexing the codebase after changes, or when the user asks about ccc, cocoindex-code, or the codebase index. Trigger phrases include 'search the codebase', 'find code related to', 'describe this file', 'read the concept guide', 'update the index', 'ccc', 'cocoindex-code'."
 ---
 
 # ccc - Semantic Code Search & Indexing
@@ -61,6 +61,71 @@ Search results include file paths and line ranges. To explore a result in more d
 
 - Use the editor's built-in file reading capabilities (e.g., the `Read` tool) to load the matched file and read lines around the returned range for full context.
 - When working in a terminal without a file-reading tool, use `sed -n '<start>,<end>p' <file>` to extract a specific line range.
+
+### Following Hints in Search Output
+
+Search results are a mixed ranking of code chunks, per-file/dir summaries, and (when configured) curated concept guides — all scored against the same query. Two kinds of hit come with a follow-up command embedded in the output:
+
+- `[summary]` — a file or directory summary. Read with `ccc describe <path>`.
+- `[guide]` — a curated concept guide. Read with `ccc guide <slug>`.
+
+When a hit carries one of these tags, follow the hint: the synthesised text is usually a faster read than chasing through individual files. Conversely, do **not** run `ccc describe .` or `ccc guide` proactively as a triage step — let search rank what's relevant and act on what it returns.
+
+## Describing Files and Directories
+
+Per-file and per-directory summaries (when configured for the project) condense each file's public API, contracts, and role into a short markdown block. They are typically faster to consult than reading the source.
+
+```bash
+ccc describe src/auth/session.py        # one file
+ccc describe src/auth/                  # directory: summary + children tree
+ccc describe .                          # project root overview
+```
+
+Use `describe` when you already know the path you want; let `ccc search` find paths for you when you don't.
+
+## Concept Guides
+
+Some projects configure cross-cutting concept guides in `.cocoindex_code/guides.yml` — synthesised markdown documents for architectural topics that span many files (e.g. memoization, plugin-SDK boundary, channel routing). Each guide names canonical files, end-to-end flow, and contracts/invariants.
+
+```bash
+ccc guide                               # list available guides + descriptions
+ccc guide <slug>                        # print one guide
+```
+
+Discovery is search-driven: a relevant guide will surface in `ccc search` results tagged `[guide]` with a `ccc guide <slug>` hint. Run `ccc guide` (no args) only when first orienting in an unfamiliar codebase or when the user explicitly asks for the guide list — not as a routine first step.
+
+### Authoring `guides.yml` Interactively
+
+When the user wants to add or improve concept guides, collaborate on the slug list rather than dumping a finished YAML. Good guide candidates are **named subsystems the codebase obviously has** — cross-cutting lifecycles, registration/dispatch protocols, end-to-end data paths. Single-file or symbol-specific topics do not warrant a guide; per-file summaries already cover those.
+
+Recommended flow:
+
+1. **Survey the codebase.** Use `ccc describe .` and a few likely subdirectory summaries to enumerate the project's subsystems and inter-edge boundaries.
+2. **Propose candidates.** Suggest 5–10 slugs with one-line descriptions, framed to name the canonical starting file or directory for each topic. Show them to the user as a list.
+3. **Iterate.** Ask which to keep, drop, rename, or merge. Surface non-obvious dependencies (`deps:`) so a higher-level guide can cite a lower-level one rather than restate it. Cycles are rejected at load time.
+4. **Write the YAML.** Add the agreed entries to `.cocoindex_code/guides.yml` (creating the file if absent). Confirm `defaults.enabled: true` and that the project's summary feature is enabled — guides require summaries.
+5. **Generate.** Run `ccc index` to drive the per-guide agent loop and produce `<slug>.md` files under `.cocoindex_code/guides/`. Re-run after editing descriptions to refresh.
+
+Schema:
+
+```yaml
+defaults:
+  enabled: true                     # disables all guides when false
+  model: openai/gpt-5.4-nano        # falls back to summary.model when omitted
+  session_budget: 200
+  max_logical_depth: 3
+  max_turns_per_session: 18
+
+guides:
+  - slug: memoization                          # [a-z0-9][a-z0-9-]*
+    description: |
+      What this guide covers, framed for the reader.
+      Name the canonical starting files (e.g. "start with src/cache.py").
+    deps: [other-slug]                         # optional; must not cycle
+    max_turns_per_session: 28                  # optional per-entry overrides
+```
+
+A multi-line description is fine and often clearer than one terse sentence — the description seeds the guide-generation agent's question, so concrete file/directory anchors pay off.
 
 ## Settings
 


### PR DESCRIPTION
## Summary

- Documents `ccc describe` and `ccc guide` in the skill, plus an authoring flow for `.cocoindex_code/guides.yml`.
- Adds a "Following Hints in Search Output" subsection: when search hits are tagged `[summary]` or `[guide]`, follow the embedded `ccc describe`/`ccc guide` hint rather than running those commands proactively as a triage step.
- Extends frontmatter trigger phrases to include `describe this file` and `read the concept guide`.

This reflects an empirical finding from running the skill across two codebases: an explicit guide-tier triage is net-neutral at best (matched and unmatched guide reads cancel out in aggregate); search-driven discovery — `ccc search` ranks guide chunks with a follow-up hint — is strictly better (~−34% tools, −26% time vs no-ccc on a 10-question battery).

## Test plan

- N/A (docs-only change to a skill file)
- CI
