### PR TITLE
fix(deps): bump typer-slim to match typer in uv.lock

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3043,15 +3043,14 @@ wheels = [
 
 [[package]]
 name = "typer-slim"
-version = "0.21.1"
+version = "0.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "typing-extensions" },
+    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/d4/064570dec6358aa9049d4708e4a10407d74c99258f8b2136bb8702303f1a/typer_slim-0.21.1.tar.gz", hash = "sha256:73495dd08c2d0940d611c5a8c04e91c2a0a98600cbd4ee19192255a233b6dbfd", size = 110478, upload-time = "2026-01-06T11:21:11.176Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/a7/e6aecc4b4eb59598829a3b5076a93aff291b4fdaa2ded25efc4e1f4d219c/typer_slim-0.24.0.tar.gz", hash = "sha256:f0ed36127183f52ae6ced2ecb2521789995992c521a46083bfcdbb652d22ad34", size = 4776, upload-time = "2026-02-16T22:08:51.2Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/0a/4aca634faf693e33004796b6cee0ae2e1dba375a800c16ab8d3eff4bb800/typer_slim-0.21.1-py3-none-any.whl", hash = "sha256:6e6c31047f171ac93cc5a973c9e617dbc5ab2bddc4d0a3135dc161b4e2020e0d", size = 47444, upload-time = "2026-01-06T11:21:12.441Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/24/5480c20380dfd18cf33d14784096dca45a24eae6102e91d49a718d3b6855/typer_slim-0.24.0-py3-none-any.whl", hash = "sha256:d5d7ee1ee2834d5020c7c616ed5e0d0f29b9a4b1dd283bdebae198ec09778d0e", size = 3394, upload-time = "2026-02-16T22:08:49.92Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump `typer-slim` from `0.21.1` to `0.24.0` in `uv.lock`. The mismatch with `typer==0.24.1` caused install-order-dependent file clobbering in shared `typer/` namespace, which manifested on `pre-commit (windows-latest, 3.11)` as `ImportError: cannot import name 'HAS_SHELLINGHAM' from 'typer.core'` during pytest collection (see PR #168 CI).
- Since `typer-slim>=0.22.0` is a meta-package that just depends on `typer` (no `typer/*.py` of its own), the namespace collision goes away.

## Test plan
- CI must turn green on `pre-commit (windows-latest, 3.11)` again — this is the failure mode the change fixes.
- Locally verified: fresh `uv sync` from scratch installs cleanly, `from cocoindex_code import cli` succeeds, and `tests/test_cli_helpers.py` + `tests/test_e2e.py` (49 tests) pass on macOS / Python 3.14.4.
