### PR TITLE
feat(doctor): surface daemon-side exception tracebacks

### DIFF
--- a/src/cocoindex_code/cli.py
+++ b/src/cocoindex_code/cli.py
@@ -703,6 +703,9 @@ def _print_doctor_result(result: DoctorCheckResult) -> None:
         _typer.echo(f"    {line}")
     for err in result.errors:
         _typer.echo(_click.style(f"    ERROR: {err}", fg="red"), err=True)
+    if result.traceback:
+        for line in result.traceback.splitlines():
+            _typer.echo(_click.style(f"    {line}", fg="bright_black"), err=True)
 
 
 @app.command()

--- a/src/cocoindex_code/client.py
+++ b/src/cocoindex_code/client.py
@@ -363,7 +363,10 @@ def doctor(
                 raise RuntimeError("Connection to daemon lost during doctor checks")
             resp = decode_response(data)
             if isinstance(resp, ErrorResponse):
-                raise RuntimeError(f"Daemon error: {resp.message}")
+                detail = f"Daemon error: {resp.message}"
+                if resp.traceback:
+                    detail += f"\n{resp.traceback}"
+                raise RuntimeError(detail)
             if isinstance(resp, DoctorResponse):
                 results.append(resp.result)
                 if on_result is not None:

--- a/src/cocoindex_code/daemon.py
+++ b/src/cocoindex_code/daemon.py
@@ -10,6 +10,7 @@ import signal
 import sys
 import threading
 import time
+import traceback
 from collections.abc import AsyncIterator, Callable
 from multiprocessing.connection import Connection, Listener
 from pathlib import Path
@@ -250,7 +251,11 @@ async def handle_connection(
                     conn.send_bytes(encode_response(resp))
             except Exception as exc:
                 logger.exception("Error during streaming response")
-                conn.send_bytes(encode_response(ErrorResponse(message=str(exc))))
+                conn.send_bytes(
+                    encode_response(
+                        ErrorResponse(message=str(exc), traceback=traceback.format_exc())
+                    )
+                )
         else:
             conn.send_bytes(encode_response(result))
     except (EOFError, OSError, asyncio.CancelledError):
@@ -359,6 +364,7 @@ async def _check_model(
         ok=False,
         details=[params_detail],
         errors=[result.error],
+        traceback=result.traceback,
     )
 
 

--- a/src/cocoindex_code/protocol.py
+++ b/src/cocoindex_code/protocol.py
@@ -154,6 +154,9 @@ class DoctorCheckResult(_msgspec.Struct):
     ok: bool
     details: list[str]
     errors: list[str]
+    # Full formatted traceback for a failed check, shown by `ccc doctor` to aid
+    # debugging of daemon-side exceptions (e.g. a failing model check).
+    traceback: str | None = None
 
 
 class DoctorResponse(_msgspec.Struct, tag="doctor"):
@@ -175,6 +178,9 @@ class DaemonEnvResponse(_msgspec.Struct, tag="daemon_env"):
 
 class ErrorResponse(_msgspec.Struct, tag="error"):
     message: str
+    # Full formatted traceback from the daemon, when the error originates from an
+    # unhandled exception. Surfaced by the CLI so daemon-side failures are debuggable.
+    traceback: str | None = None
 
 
 Response = (

--- a/src/cocoindex_code/shared.py
+++ b/src/cocoindex_code/shared.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import logging
 import pathlib
+import traceback as _tb
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Annotated, Any, NamedTuple, Union
 
@@ -47,11 +48,14 @@ def is_sentence_transformers_installed() -> bool:
 class EmbeddingCheckResult(NamedTuple):
     """Outcome of a single embed-test call. See `check_embedding`.
 
-    Exactly one of ``dim`` / ``error`` is set: ``error is None`` means success.
+    On success ``error is None`` and ``dim`` holds the embedding dimension. On
+    failure ``error`` holds a one-line summary and ``traceback`` the full
+    formatted traceback (for surfacing daemon-side stack traces in `ccc doctor`).
     """
 
     dim: int | None
     error: str | None
+    traceback: str | None = None
 
 
 async def check_embedding(
@@ -73,7 +77,7 @@ async def check_embedding(
         msg = " ".join(f"{type(e).__name__}: {e}".splitlines())
         if len(msg) > 500:
             msg = msg[:500] + "…"
-        return EmbeddingCheckResult(dim=None, error=msg)
+        return EmbeddingCheckResult(dim=None, error=msg, traceback=_tb.format_exc())
 
 
 def create_embedder(

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -846,6 +846,10 @@ async def test_daemon_check_model_maps_failure_to_doctor_result() -> None:
     assert len(result.errors) == 1
     assert result.errors[0].startswith("RuntimeError:")
     assert "boom" in result.errors[0]
+    # The full traceback is carried through so `ccc doctor` can display it.
+    assert result.traceback is not None
+    assert "Traceback (most recent call last):" in result.traceback
+    assert "boom" in result.traceback
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_shared.py
+++ b/tests/test_shared.py
@@ -98,6 +98,7 @@ async def test_check_embedding_ok() -> None:
     result = await check_embedding(_StubOkEmbedder())
     assert result.error is None
     assert result.dim == 384
+    assert result.traceback is None
 
 
 async def test_check_embedding_error() -> None:
@@ -106,6 +107,10 @@ async def test_check_embedding_error() -> None:
     assert result.error is not None
     assert result.error.startswith("RuntimeError:")
     assert "boom" in result.error
+    # The full traceback is captured so `ccc doctor` can surface it for debugging.
+    assert result.traceback is not None
+    assert "Traceback (most recent call last):" in result.traceback
+    assert "boom" in result.traceback
 
 
 async def test_check_embedding_forwards_params() -> None:


### PR DESCRIPTION
## Summary
- Surface daemon-side exception tracebacks in `ccc doctor` so failures (e.g. a failing model check) are debuggable instead of showing only a one-line, truncated summary.
- Per-check failures: add `traceback` to `EmbeddingCheckResult` and `DoctorCheckResult`; `check_embedding` captures `format_exc()`, `_check_model` propagates it, and the CLI prints it dimmed/indented under the error.
- Streaming exceptions: add `traceback` to `ErrorResponse`, populated by the daemon's streaming handler and appended to the client-raised `RuntimeError`.
- Both new fields default to `None`, keeping the msgpack wire format backward-compatible.

Closes #173.

## Test plan
- `uv run mypy .` — clean (40 files).
- `uv run pytest tests/` — extended `test_shared.py` and `test_e2e.py` assert the traceback is captured by `check_embedding` and propagated through `_check_model`.
- CI.
