### PR TITLE
fix(init): clearer providers, interactive recovery, retry-crash fix

### DIFF
--- a/src/cocoindex_code/cli.py
+++ b/src/cocoindex_code/cli.py
@@ -321,12 +321,35 @@ def remove_from_gitignore(project_root: Path) -> None:
 _LITELLM_MODELS_URL = "https://docs.litellm.ai/docs/embedding/supported_embedding"
 
 
+def _st_model_rejection_reason(model: str) -> str | None:
+    """Why ``model`` can't be a sentence-transformers model, or None if it's fine.
+
+    sentence-transformers loads HuggingFace model ids. An ``ollama/`` prefix is a
+    LiteLLM/Ollama route that ST tries (and fails) to resolve as a HuggingFace
+    repo — the user wants the litellm provider instead (issue #181). Real
+    HuggingFace ids that contain an ``org/`` slash (``Snowflake/...``,
+    ``openai/...``) are left alone.
+    """
+    if model.strip().lower().startswith("ollama/"):
+        return (
+            "ollama/… models run via litellm, not sentence-transformers — "
+            "go back and pick the litellm provider instead."
+        )
+    return None
+
+
 def _resolve_embedding_choice(
     litellm_model_flag: str | None,
     st_installed: bool,
     tty: bool,
+    previous: EmbeddingSettings | None = None,
 ) -> EmbeddingSettings:
-    """Resolve the embedding settings per the init control-flow diagram."""
+    """Resolve the embedding settings per the init control-flow diagram.
+
+    On a retry, ``previous`` holds the choice from the last attempt; its
+    provider and model become the prompt defaults so the user only edits
+    what was wrong instead of retyping everything.
+    """
     if litellm_model_flag is not None:
         return EmbeddingSettings(provider="litellm", model=litellm_model_flag)
 
@@ -349,14 +372,15 @@ def _resolve_embedding_choice(
             "Embedding provider",
             choices=[
                 questionary.Choice(
-                    title="sentence-transformers (local, free)",
+                    title="sentence-transformers (local, free — built-in HuggingFace models)",
                     value="sentence-transformers",
                 ),
                 questionary.Choice(
-                    title="litellm (cloud, 100+ providers)",
+                    title="litellm (100+ providers — cloud APIs & local Ollama)",
                     value="litellm",
                 ),
             ],
+            default=previous.provider if previous is not None else None,
         ).ask()
     else:
         _typer.echo(
@@ -369,10 +393,16 @@ def _resolve_embedding_choice(
         raise _typer.Exit(code=1)
 
     if provider == "sentence-transformers":
-        model = questionary.text("Model name", default=DEFAULT_ST_MODEL).ask()
+        default_model = previous.model if previous is not None else DEFAULT_ST_MODEL
+        model = questionary.text(
+            "Model name",
+            default=default_model,
+            validate=lambda m: _st_model_rejection_reason(m) or True,
+        ).ask()
     elif provider == "litellm":
         _typer.echo(f"See supported LiteLLM embedding models: {_LITELLM_MODELS_URL}")
-        model = questionary.text("Model name").ask()
+        default_model = previous.model if previous is not None else ""
+        model = questionary.text("Model name", default=default_model).ask()
     else:
         _typer.echo(f"Error: unknown provider {provider!r}", err=True)
         raise _typer.Exit(code=1)
@@ -392,13 +422,14 @@ def _ok_fail_tag(ok: bool) -> str:
     return _click.style("[FAIL]", fg="red", bold=True)
 
 
-def _run_init_model_check(settings_path: Path) -> None:
-    """Ask the daemon to test the embedding model; print results and a hint on failure.
+def _run_init_model_check() -> bool:
+    """Ask the daemon to test the embedding model; print results. Return True if all pass.
 
     Drives the check via `DoctorRequest(project_root=None)`. The daemon loads
     the model once and stays running, so the user's next `ccc index` starts
     warm. Both DaemonStartError and generic exceptions are rendered as a
-    synthetic failed DoctorCheckResult — uniform failure-output shape.
+    synthetic failed DoctorCheckResult — uniform failure-output shape. The
+    caller decides what to show on failure (retry prompt / next-steps block).
     """
     from rich.console import Console as _Console
     from rich.live import Live as _Live
@@ -426,55 +457,101 @@ def _run_init_model_check(settings_path: Path) -> None:
             )
         ]
 
-    failed = False
+    ok = True
     for r in results:
         if r.name == "done":
             continue
-        _print_doctor_result(r)
+        _print_doctor_result(r, verbose=False)
         if not r.ok:
-            failed = True
+            ok = False
+    return ok
 
-    if failed:
-        display_path = format_path_for_display(settings_path)
-        _typer.echo(
-            f"You can edit {display_path} to change the model or add API keys\n"
-            "under `envs:`. Then run `ccc doctor` to verify.",
-            err=True,
-        )
+
+def _print_init_next_steps(settings_path: Path) -> None:
+    """Prominent recovery block shown after a failed init model check."""
+    import click as _click
+
+    display_path = format_path_for_display(settings_path)
+    _typer.echo(err=True)
+    _typer.echo(_click.style("  Next steps", bold=True), err=True)
+    _typer.echo(_click.style(f"  {'─' * 38}", fg="bright_black"), err=True)
+    _typer.echo(
+        f"  1. Edit  {_click.style(display_path, fg='cyan', bold=True)}\n"
+        "     to change the model or add API keys under `envs:`.",
+        err=True,
+    )
+    _typer.echo("  2. Run  `ccc doctor`  to verify.", err=True)
+    _typer.echo()  # trailing blank before whatever init prints next
 
 
 def _setup_user_settings_interactive(litellm_model_flag: str | None) -> None:
-    """Interactive global-settings setup — only runs when settings are missing."""
+    """Interactive global-settings setup — only runs when settings are missing.
+
+    Loops until the configured model passes its check or the user chooses to
+    keep the current settings. On failure we offer a retry, but only when we
+    can actually re-prompt for a different model — i.e. interactive and not
+    pinned by ``--litellm-model``; otherwise we just print the next steps.
+    """
     from .embedder_defaults import lookup_defaults
     from .shared import is_sentence_transformers_installed
 
-    embedding = _resolve_embedding_choice(
-        litellm_model_flag=litellm_model_flag,
-        st_installed=is_sentence_transformers_installed(),
-        tty=sys.stdin.isatty(),
-    )
+    st_installed = is_sentence_transformers_installed()
+    interactive = sys.stdin.isatty()
+    previous: EmbeddingSettings | None = None
 
-    # Apply curated defaults if the model is in our table.
-    indexing_defaults, query_defaults = lookup_defaults(embedding.provider, embedding.model)
-    defaults_applied = indexing_defaults is not None or query_defaults is not None
-    if defaults_applied:
-        embedding.indexing_params = indexing_defaults or {}
-        embedding.query_params = query_defaults or {}
+    while True:
+        embedding = _resolve_embedding_choice(
+            litellm_model_flag=litellm_model_flag,
+            st_installed=st_installed,
+            tty=interactive,
+            previous=previous,
+        )
+        previous = embedding  # remembered as the defaults for a potential retry
 
-    path = save_initial_user_settings(embedding, defaults_applied=defaults_applied)
-    _typer.echo()
-    _typer.echo(f"Created user settings: {format_path_for_display(path)}")
+        # Apply curated defaults if the model is in our table.
+        indexing_defaults, query_defaults = lookup_defaults(embedding.provider, embedding.model)
+        defaults_applied = indexing_defaults is not None or query_defaults is not None
+        if defaults_applied:
+            embedding.indexing_params = indexing_defaults or {}
+            embedding.query_params = query_defaults or {}
 
-    if defaults_applied:
+        path = save_initial_user_settings(embedding, defaults_applied=defaults_applied)
         _typer.echo()
-        _typer.echo(f"Applied recommended defaults for {embedding.model}:")
-        _typer.echo(f"  indexing_params: {embedding.indexing_params}")
-        _typer.echo(f"  query_params:    {embedding.query_params}")
+        _typer.echo(f"Created user settings: {format_path_for_display(path)}")
 
-    _typer.echo()
-    _typer.echo(f"Testing embedding model: {embedding.provider} / {embedding.model}")
-    _run_init_model_check(path)
-    _typer.echo()
+        if defaults_applied:
+            _typer.echo()
+            _typer.echo(f"Applied recommended defaults for {embedding.model}:")
+            _typer.echo(f"  indexing_params: {embedding.indexing_params}")
+            _typer.echo(f"  query_params:    {embedding.query_params}")
+
+        _typer.echo()
+        _typer.echo(f"Testing embedding model: {embedding.provider} / {embedding.model}")
+        if _run_init_model_check():
+            _typer.echo()
+            return
+
+        # Model check failed. Retry only makes sense if we can re-prompt.
+        if interactive and litellm_model_flag is None:
+            import questionary
+
+            _typer.echo()  # separate the failure output from the prompt below
+            choice = questionary.select(
+                "The embedding model couldn't be loaded. What would you like to do?",
+                choices=[
+                    questionary.Choice(title="Try a different provider/model", value="retry"),
+                    questionary.Choice(
+                        title="Keep these settings and finish — I'll edit the file myself",
+                        value="keep",
+                    ),
+                ],
+            ).ask()
+            if choice == "retry":
+                continue
+            # "keep" or None (cancelled) falls through to the next-steps block.
+
+        _print_init_next_steps(path)
+        return
 
 
 @app.command()
@@ -692,7 +769,7 @@ def _print_error(msg: str) -> None:
     _typer.echo(_click.style(f"  ERROR: {msg}", fg="red"), err=True)
 
 
-def _print_doctor_result(result: DoctorCheckResult) -> None:
+def _print_doctor_result(result: DoctorCheckResult, *, verbose: bool = False) -> None:
     import click as _click
 
     if result.name == "done":
@@ -704,13 +781,26 @@ def _print_doctor_result(result: DoctorCheckResult) -> None:
     for err in result.errors:
         _typer.echo(_click.style(f"    ERROR: {err}", fg="red"), err=True)
     if result.traceback:
-        for line in result.traceback.splitlines():
-            _typer.echo(_click.style(f"    {line}", fg="bright_black"), err=True)
+        if verbose:
+            for line in result.traceback.splitlines():
+                _typer.echo(_click.style(f"    {line}", fg="bright_black"), err=True)
+        else:
+            _typer.echo(
+                _click.style("    Run `ccc doctor -v` for the full traceback.", fg="bright_black"),
+                err=True,
+            )
 
 
 @app.command()
 @_catch_daemon_start_error
-def doctor() -> None:
+def doctor(
+    verbose: bool = _typer.Option(
+        False,
+        "-v",
+        "--verbose",
+        help="Show full exception tracebacks for failed checks.",
+    ),
+) -> None:
     """Check system health and report issues."""
     from . import client as _client
     from .settings import (
@@ -719,6 +809,9 @@ def doctor() -> None:
     from .settings import (
         load_user_settings as _load_user_settings,
     )
+
+    def _on_result(result: DoctorCheckResult) -> None:
+        _print_doctor_result(result, verbose=verbose)
 
     # --- 1. Global settings (local, no daemon needed) ---
     _print_section("Global Settings")
@@ -773,7 +866,7 @@ def doctor() -> None:
         try:
             _client.doctor(
                 project_root=None,
-                on_result=_print_doctor_result,
+                on_result=_on_result,
             )
         except Exception as e:
             _print_error(f"Model check failed: {e}")
@@ -804,7 +897,7 @@ def doctor() -> None:
         try:
             _client.doctor(
                 project_root=str(project_root),
-                on_result=_print_doctor_result,
+                on_result=_on_result,
             )
         except Exception as e:
             _print_error(f"Project checks failed: {e}")

--- a/src/cocoindex_code/client.py
+++ b/src/cocoindex_code/client.py
@@ -111,25 +111,33 @@ def _connect_and_handshake() -> Connection:
 
     Returns the open connection for the caller to send exactly one request.
 
-    On the first call, automatically starts or
-    restarts the daemon if needed.  Subsequent calls fail fast with
-    ``DaemonVersionError`` on mismatch (indicating the daemon was replaced
-    mid-session, e.g. after a tool upgrade).
+    Automatically starts or restarts the daemon when it is absent or running
+    with stale global settings (e.g. a ``ccc init`` retry rewrote
+    ``global_settings.yml`` after the daemon loaded it). A genuine *version*
+    mismatch after we have already reached a matching daemon means the binary
+    was replaced under us mid-session — that fails fast instead of looping on
+    restarts.
     """
     global _daemon_ensured  # noqa: PLW0603
 
-    if _daemon_ensured:
-        return _raw_connect_and_handshake()
-
-    # First connection — auto-start/restart as needed.
     try:
         conn = _raw_connect_and_handshake()
         _daemon_ensured = True
         return conn
-    except DaemonVersionError:
+    except DaemonVersionError as e:
+        # `resp.ok` is False only for a real version mismatch. Once we have
+        # ensured a matching daemon, a fresh version mismatch means the binary
+        # was swapped under us — fail fast. A settings-only restart request
+        # (resp.ok True, but the loaded settings mtime moved) is expected;
+        # restart the daemon below so it reloads them.
+        if _daemon_ensured and not e.resp.ok:
+            raise
         stop_daemon()
     except (ConnectionRefusedError, OSError):
-        pass
+        # No daemon answered. Normal on the first call (start one below); if we
+        # had already ensured one it vanished mid-session — surface that.
+        if _daemon_ensured:
+            raise
 
     if _is_daemon_supervised():
         # Supervisor is responsible for (re)starting the daemon — just wait
@@ -192,10 +200,16 @@ class DaemonVersionError(RuntimeError):
 
     def __init__(self, resp: HandshakeResponse) -> None:
         self.resp = resp
-        super().__init__(
-            f"Daemon version mismatch (daemon={resp.daemon_version}, "
-            f"client={__version__}). Please retry — the daemon may need a restart."
-        )
+        if not resp.ok:
+            message = (
+                f"Daemon version mismatch (daemon={resp.daemon_version}, "
+                f"client={__version__}). Please retry — the daemon may need a restart."
+            )
+        else:
+            message = (
+                "Daemon is running with stale global settings and needs a restart. Please retry."
+            )
+        super().__init__(message)
 
 
 class DaemonStartError(RuntimeError):

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -229,7 +229,7 @@ def test_init_auto_populates_known_model(
         "_resolve_embedding_choice",
         lambda **_kw: EmbeddingSettings(provider="litellm", model="cohere/embed-english-v3.0"),
     )
-    monkeypatch.setattr(cli, "_run_init_model_check", lambda path: None)
+    monkeypatch.setattr(cli, "_run_init_model_check", lambda: True)
 
     cli._setup_user_settings_interactive(litellm_model_flag=None)
 
@@ -264,7 +264,7 @@ def test_init_writes_comment_template_for_unknown_model(
         "_resolve_embedding_choice",
         lambda **_kw: EmbeddingSettings(provider="litellm", model="someprovider/unknown-model"),
     )
-    monkeypatch.setattr(cli, "_run_init_model_check", lambda path: None)
+    monkeypatch.setattr(cli, "_run_init_model_check", lambda: True)
 
     cli._setup_user_settings_interactive(litellm_model_flag=None)
 
@@ -275,3 +275,128 @@ def test_init_writes_comment_template_for_unknown_model(
     loaded = load_user_settings()
     assert loaded.embedding.indexing_params is None
     assert loaded.embedding.query_params is None
+
+
+def test_init_failed_check_prints_next_steps_and_keeps_settings(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When the model check fails and we can't re-prompt (non-interactive), the
+    settings file is kept and a 'Next steps' recovery block is printed.
+    """
+    from cocoindex_code.settings import EmbeddingSettings, user_settings_path
+
+    user_dir = tmp_path / ".cocoindex_code"
+    monkeypatch.setenv("COCOINDEX_CODE_DIR", str(user_dir))
+
+    monkeypatch.setattr(
+        cli,
+        "_resolve_embedding_choice",
+        lambda **_kw: EmbeddingSettings(provider="litellm", model="someprovider/unknown-model"),
+    )
+    monkeypatch.setattr(cli, "_run_init_model_check", lambda: False)
+    # Non-interactive: no retry prompt, falls straight through to next steps.
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
+
+    cli._setup_user_settings_interactive(litellm_model_flag=None)
+
+    err = capsys.readouterr().err
+    assert "Next steps" in err
+    assert "ccc doctor" in err
+    # Settings are kept on disk so the user can edit them.
+    assert user_settings_path().is_file()
+
+
+def test_resolve_embedding_choice_prefills_previous_on_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On retry, last attempt's provider and model become the prompt defaults."""
+    import questionary
+
+    from cocoindex_code.settings import EmbeddingSettings
+
+    captured: dict[str, object] = {}
+
+    class _FakeQuestion:
+        def __init__(self, value: object) -> None:
+            self._value = value
+
+        def ask(self) -> object:
+            return self._value
+
+    def _fake_select(
+        message: str, choices: object, default: object = None, **_kw: object
+    ) -> _FakeQuestion:
+        captured["select_default"] = default
+        return _FakeQuestion("litellm")
+
+    def _fake_text(message: str, default: str = "", **_kw: object) -> _FakeQuestion:
+        captured["text_default"] = default
+        return _FakeQuestion("openai/text-embedding-3-small")
+
+    monkeypatch.setattr(questionary, "select", _fake_select)
+    monkeypatch.setattr(questionary, "text", _fake_text)
+
+    previous = EmbeddingSettings(provider="litellm", model="ollama/nomic-embed-text")
+    result = cli._resolve_embedding_choice(
+        litellm_model_flag=None,
+        st_installed=True,
+        tty=True,
+        previous=previous,
+    )
+
+    # Provider select is pre-pointed at last time's provider; model is pre-filled.
+    assert captured["select_default"] == "litellm"
+    assert captured["text_default"] == "ollama/nomic-embed-text"
+    assert result.provider == "litellm"
+    assert result.model == "openai/text-embedding-3-small"
+
+
+def test_st_model_rejection_reason_flags_ollama_prefix() -> None:
+    """`ollama/` models can't be used with sentence-transformers; valid HF ids pass."""
+    reason = cli._st_model_rejection_reason("ollama/nomic-embed-text")
+    assert reason is not None and "litellm" in reason
+    # Case-insensitive and whitespace-tolerant.
+    assert cli._st_model_rejection_reason("  OLLAMA/foo ") is not None
+    # Real HuggingFace ids with an `org/` slash must not false-positive.
+    assert cli._st_model_rejection_reason("Snowflake/snowflake-arctic-embed-xs") is None
+    assert cli._st_model_rejection_reason("openai/clip-vit-base-patch32") is None
+
+
+def test_resolve_embedding_choice_validates_st_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The sentence-transformers model prompt gets a validator that rejects
+    `ollama/` models inline (before anything is written or tested)."""
+    import questionary
+
+    captured: dict[str, object] = {}
+
+    class _FakeQuestion:
+        def __init__(self, value: object) -> None:
+            self._value = value
+
+        def ask(self) -> object:
+            return self._value
+
+    def _fake_select(
+        message: str, choices: object, default: object = None, **_kw: object
+    ) -> _FakeQuestion:
+        return _FakeQuestion("sentence-transformers")
+
+    def _fake_text(
+        message: str, default: str = "", validate: object = None, **_kw: object
+    ) -> _FakeQuestion:
+        captured["validate"] = validate
+        return _FakeQuestion("Snowflake/snowflake-arctic-embed-xs")
+
+    monkeypatch.setattr(questionary, "select", _fake_select)
+    monkeypatch.setattr(questionary, "text", _fake_text)
+
+    cli._resolve_embedding_choice(litellm_model_flag=None, st_installed=True, tty=True)
+
+    validate = captured["validate"]
+    assert callable(validate)
+    assert validate("ollama/nomic-embed-text") is not True  # rejected (returns message)
+    assert validate("Snowflake/snowflake-arctic-embed-xs") is True

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -77,3 +77,78 @@ def test_print_handshake_warnings_no_warnings_prints_nothing(
     monkeypatch.setattr(client, "_surfaced_warnings", set())
     client._print_handshake_warnings(HandshakeResponse(ok=True, daemon_version="x"))
     assert capsys.readouterr().err == ""
+
+
+def test_connect_restarts_ensured_daemon_on_stale_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An already-ensured daemon reporting stale global settings (resp.ok True,
+    moved mtime) is restarted, not surfaced as an error. This is the `ccc init`
+    retry path, where rewriting global_settings.yml changes its mtime.
+    """
+    from cocoindex_code.protocol import HandshakeResponse
+
+    monkeypatch.setattr(client, "_daemon_ensured", True)
+
+    sentinel_conn = object()
+    calls = {"raw": 0, "stop": 0, "start": 0}
+
+    def fake_raw() -> object:
+        calls["raw"] += 1
+        if calls["raw"] == 1:
+            raise client.DaemonVersionError(
+                HandshakeResponse(ok=True, daemon_version="v1", global_settings_mtime_us=1)
+            )
+        return sentinel_conn
+
+    monkeypatch.setattr(client, "_raw_connect_and_handshake", fake_raw)
+    monkeypatch.setattr(client, "stop_daemon", lambda: calls.update(stop=calls["stop"] + 1))
+    monkeypatch.setattr(client, "start_daemon", lambda: calls.update(start=calls["start"] + 1))
+    monkeypatch.setattr(client, "_wait_for_daemon", lambda **_kw: None)
+    monkeypatch.setattr(client, "_is_daemon_supervised", lambda: False)
+
+    conn = client._connect_and_handshake()
+
+    assert conn is sentinel_conn
+    assert calls["stop"] == 1  # old daemon stopped
+    assert calls["start"] == 1  # fresh daemon started to reload settings
+    assert calls["raw"] == 2  # reconnected after restart
+
+
+def test_connect_fails_fast_on_version_mismatch_after_ensured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A genuine version mismatch (resp.ok False) after the daemon was already
+    ensured means the binary was swapped under us — fail fast, don't restart.
+    """
+    from cocoindex_code.protocol import HandshakeResponse
+
+    monkeypatch.setattr(client, "_daemon_ensured", True)
+    started = {"start": 0}
+
+    def fake_raw() -> object:
+        raise client.DaemonVersionError(HandshakeResponse(ok=False, daemon_version="other-version"))
+
+    monkeypatch.setattr(client, "_raw_connect_and_handshake", fake_raw)
+    monkeypatch.setattr(client, "stop_daemon", lambda: None)
+    monkeypatch.setattr(client, "start_daemon", lambda: started.update(start=1))
+    monkeypatch.setattr(client, "_wait_for_daemon", lambda **_kw: None)
+    monkeypatch.setattr(client, "_is_daemon_supervised", lambda: False)
+
+    with pytest.raises(client.DaemonVersionError):
+        client._connect_and_handshake()
+    assert started["start"] == 0  # never tried to restart
+
+
+def test_daemon_version_error_message_reflects_cause() -> None:
+    """The error text matches the real cause — not always "version mismatch"."""
+    from cocoindex_code.protocol import HandshakeResponse
+
+    version_err = client.DaemonVersionError(HandshakeResponse(ok=False, daemon_version="x"))
+    assert "version mismatch" in str(version_err)
+
+    settings_err = client.DaemonVersionError(
+        HandshakeResponse(ok=True, daemon_version="x", global_settings_mtime_us=1)
+    )
+    assert "stale global settings" in str(settings_err)
+    assert "version mismatch" not in str(settings_err)


### PR DESCRIPTION
## Summary

Addresses several `ccc init` problems reported in #181. This is **not** a full
close of the issue — input-validation breadth and docs/README updates remain as
follow-ups.

- **Provider labels:** local Ollama is now clearly under `litellm`
  (`litellm (100+ providers — cloud APIs & local Ollama)`); sentence-transformers
  is labeled as built-in HuggingFace models, so users no longer pick it for an
  `ollama/` model.
- **Input validation:** the sentence-transformers model prompt rejects `ollama/…`
  models inline, before anything is written to disk or tested.
- **Interactive recovery:** a failed init model check now loops with a
  "try a different model / keep & finish" choice, pre-filling the previous
  provider + model on retry, and prints a prominent **Next steps** recovery block.
- **`ccc doctor -v`:** default output shows the one-line error plus a hint to
  rerun with `-v`; `-v` shows the full traceback.
- **Retry-crash fix:** rewriting `global_settings.yml` on retry made the
  already-ensured daemon report a bogus "version mismatch" (identical versions).
  The client now restarts the daemon on a stale-settings handshake even after it
  was ensured, while still failing fast on a genuine mid-session version mismatch.
  `DaemonVersionError`'s message now reflects the real cause.

## Test plan

- `uv run mypy .` (clean) and `uv run pytest tests/` (200 passed locally)
- New tests: retry pre-fill of provider/model, `ollama/` rejection (no false
  positives on `Snowflake/`, `openai/`), failed-check next-steps, daemon
  restart-on-stale-settings vs. fail-fast on version mismatch, reason-aware
  `DaemonVersionError` message
- CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
