### PR TITLE
feat: include .dart files in default search patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,7 @@ embedding:
 | cpp | c++ | `.cpp`, `.cc`, `.cxx`, `.h`, `.hpp` |
 | csharp | csharp, cs | `.cs` |
 | css | | `.css`, `.scss` |
+| dart | | `.dart` |
 | dtd | | `.dtd` |
 | fortran | f, f90, f95, f03 | `.f`, `.f90`, `.f95`, `.f03` |
 | go | golang | `.go` |

--- a/src/cocoindex_code/settings.py
+++ b/src/cocoindex_code/settings.py
@@ -37,6 +37,7 @@ DEFAULT_INCLUDED_PATTERNS: list[str] = [
     "**/*.hxx",  # C++ headers
     "**/*.hh",  # C++ headers
     "**/*.cs",  # C#
+    "**/*.dart",  # Dart
     "**/*.sql",  # SQL
     "**/*.sh",  # Shell
     "**/*.bash",  # Bash

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -64,6 +64,10 @@ def test_default_project_settings() -> None:
     assert s.language_overrides == []
 
 
+def test_default_included_patterns_cover_dart() -> None:
+    assert "**/*.dart" in DEFAULT_INCLUDED_PATTERNS
+
+
 @pytest.mark.usefixtures("_patch_user_dir")
 def test_save_and_load_user_settings(tmp_path: Path) -> None:
     settings = UserSettings(


### PR DESCRIPTION
## Summary

`.dart` files were excluded from `DEFAULT_INCLUDED_PATTERNS`, so Dart sources were not indexed (#183).

## Fix

Add the `**/*.dart` glob to `DEFAULT_INCLUDED_PATTERNS` and the corresponding row to the README "Supported Languages" table, mirroring how Svelte/Vue were added in #158. Dart chunking falls back to upstream cocoindex tree-sitter support.

Closes #183
