### PR TITLE
feat: include Salesforce Apex files in default patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,7 @@ embedding:
 
 | Language | Aliases | File Extensions |
 |----------|---------|-----------------|
+| apex | | `.cls`, `.trigger` |
 | c | | `.c` |
 | cpp | c++ | `.cpp`, `.cc`, `.cxx`, `.h`, `.hpp` |
 | csharp | csharp, cs | `.cs` |

--- a/src/cocoindex_code/settings.py
+++ b/src/cocoindex_code/settings.py
@@ -28,6 +28,8 @@ DEFAULT_INCLUDED_PATTERNS: list[str] = [
     "**/*.rs",  # Rust
     "**/*.go",  # Go
     "**/*.java",  # Java
+    "**/*.cls",  # Salesforce Apex classes
+    "**/*.trigger",  # Salesforce Apex triggers
     "**/*.c",  # C
     "**/*.h",  # C/C++ headers
     "**/*.cpp",  # C++

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -64,6 +64,11 @@ def test_default_project_settings() -> None:
     assert s.language_overrides == []
 
 
+def test_default_include_patterns_include_salesforce_apex() -> None:
+    assert "**/*.cls" in DEFAULT_INCLUDED_PATTERNS
+    assert "**/*.trigger" in DEFAULT_INCLUDED_PATTERNS
+
+
 @pytest.mark.usefixtures("_patch_user_dir")
 def test_save_and_load_user_settings(tmp_path: Path) -> None:
     settings = UserSettings(


### PR DESCRIPTION
## Summary

Salesforce Apex files are not indexed by default because `.cls` class files and `.trigger` trigger files are missing from `DEFAULT_INCLUDED_PATTERNS`.

This keeps the change scoped to default file matching and docs. `detect_code_language()` already recognizes `.cls` and `.trigger` files as `apex`.

## Changes

- Add `**/*.cls` and `**/*.trigger` to the default include patterns.
- Document Apex in the README supported languages table.
- Add a focused regression test for the default include patterns.

Closes #175

## Verification

- `uv run pytest tests/test_settings.py::test_default_project_settings -q`
- `uv run pytest tests/test_settings.py -q`
- `uv run ruff check src/cocoindex_code/settings.py tests/test_settings.py`
- `uv run mypy src/cocoindex_code/settings.py tests/test_settings.py`
- `git diff --check`
- `uv run prek run --all-files` — non-pytest hooks passed (`ruff`, `ruff-format`, `uv-lock`, `mypy`, and basic file checks); the pytest hook is blocked in this local environment by `sqlite_vec/vec0.so: wrong ELF class: ELFCLASS32` and a local HuggingFace cache permission issue.
