### PR TITLE
docs: clarify updating the index after settings changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -508,6 +508,14 @@ chunkers:
 
 > `.cocoindex_code/` is automatically added to `.gitignore` during init.
 
+After editing `include_patterns`, `exclude_patterns`, or `language_overrides`:
+
+- Run `ccc doctor` to preview which files match.
+- Run `ccc index` or `ccc search --refresh ...` to update the existing index.
+- You do not need to delete the index or restart the daemon for these file-matching changes.
+
+If you add or change custom `chunkers`, restart the daemon first so the chunker registry is reloaded, then run `ccc index`.
+
 Use `chunkers` when you want to control how a file type is split into chunks before indexing.
 
 `module: example_toml_chunker:toml_chunker` means:


### PR DESCRIPTION
## Summary

Clarifies what to do after editing project settings such as `include_patterns`, `exclude_patterns`, or `language_overrides`.

## Changes

- Document using `ccc doctor` to preview which files match after settings edits.
- Document running `ccc index` or `ccc search --refresh ...` to update the existing index.
- Clarify that file-matching settings do not require deleting the index or restarting the daemon.
- Note the custom `chunkers` exception: restart the daemon so the chunker registry reloads before indexing.

Closes #160

## Verification

- `git diff --check`
- README content probe for the new settings-update guidance
- `uv run prek run --files README.md` — README file hooks passed; the pytest hook is blocked in this local environment by `sqlite_vec/vec0.so: wrong ELF class: ELFCLASS32` and a local HuggingFace cache permission issue.
