### PR TITLE
docs: add Kilo Code MCP setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,24 @@ Or use opencode.json:
 ```
 </details>
 
+<details>
+<summary>Kilo Code</summary>
+
+Add a local MCP server in `~/.config/kilo/kilo.jsonc`, `kilo.jsonc`, or `.kilo/kilo.jsonc`:
+
+```json
+{
+  "mcp": {
+    "cocoindex-code": {
+      "type": "local",
+      "command": ["ccc", "mcp"],
+      "enabled": true
+    }
+  }
+}
+```
+</details>
+
 Once configured, the agent automatically decides when semantic code search is helpful — finding code by description, exploring unfamiliar codebases, fuzzy/conceptual matches, or locating implementations without knowing exact names.
 
 > **Note:** The `cocoindex-code` command (without subcommand) still works as an MCP server for backward compatibility. It auto-creates settings from environment variables on first run.


### PR DESCRIPTION
Closes #24

## Summary

- Add Kilo Code MCP setup instructions to the README's coding-agent integration section.
- Document the current `kilo.jsonc` `mcp` config shape for running `ccc mcp` as a local MCP server.
- Align the README with the linked Reddit background that cocoindex-code started working in Kilo Code pre-release 7.0.33.

## Validation

- Verified the Reddit background via the public Reddit RSS route: the linked comment says this started working in Kilo Code pre-release 7.0.33.
- Verified the issue is still open and unassigned.
- Checked the issue timeline and duplicate PR/issue searches for Kilo/README/Reddit-link wording; no duplicate PR found.
- Verified the README previously had Claude Code, Codex, and OpenCode MCP setup examples but no Kilo Code instructions.
- Checked current Kilo docs for `kilo.jsonc` MCP configuration: global/project config paths, `mcp` key, local `type`, `command`, and `enabled` fields.
- Checked the updated README section for balanced `<details>` blocks, final newline, no trailing whitespace, no added credential-like strings, and `git diff --check`.
- Ran README-scoped pre-commit doc hooks for trailing whitespace, end-of-file, added-large-files, and merge-conflict checks; all passed.

Note: running the full pre-commit hook on `README.md` also invokes the repository-wide pytest hook (`pass_filenames: false`). That fails in my local environment because of existing sqlite_vec/HuggingFace cache setup issues, not because of this README-only documentation patch.
