### PR TITLE
Add server.json for MCP Server Registry publishing

### DIFF
--- a/server.json
+++ b/server.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.cocoindex-io/cocoindex-code",
+  "title": "CocoIndex Code",
+  "description": "AST/tree-sitter code search MCP server that indexes a codebase and returns compact, relevant snippets to reduce coding-agent context usage.",
+  "repository": {
+    "url": "https://github.com/cocoindex-io/cocoindex-code",
+    "source": "github"
+  },
+  "version": "0.2.37",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "registryBaseUrl": "https://pypi.org",
+      "identifier": "cocoindex-code",
+      "version": "0.2.37",
+      "runtimeHint": "uvx",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [
+        {
+          "type": "positional",
+          "value": "mcp"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a `server.json` so cocoindex-code can be published to the [official MCP Server Registry](https://github.com/modelcontextprotocol/registry). Registering there auto-propagates the listing to downstream directories that crawl the registry (Glama, PulseMCP, best-of-mcp-servers), so it's the highest-leverage single listing.

Manifest uses the `2025-12-11` schema, name `io.github.cocoindex-io/cocoindex-code`, PyPI package `cocoindex-code` v0.2.37, `uvx` runtime, stdio transport, with `mcp` as the package argument.

**⚠️ Verify before publishing:** the package exposes two console scripts (`ccc` and `cocoindex-code`) and the MCP entry point is `ccc mcp`. With `runtimeHint: uvx` the registry will invoke `uvx cocoindex-code mcp`. Confirm that command actually launches the MCP server (i.e. the `cocoindex-code` entry point routes to the same CLI app). If not, adjust `identifier`/`packageArguments` accordingly (e.g. the package may need the default script to start the server, or use a different invocation).

To publish after merge: `mcp-publisher login github` (as a cocoindex-io org member) then `mcp-publisher publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)