### PR TITLE
fix(cli): make 'ccc index' auto-initialize project settings as README claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ ccc search "authentication logic"       # search!
 
 The background daemon starts automatically on first use.
 
-> **Tip:** `ccc index` auto-initializes if you haven't run `ccc init` yet, so you can skip straight to indexing.
+> **Tip:** Once global settings exist (created by your first `ccc init` on the machine), `ccc index` auto-initializes new projects with default settings — you can skip `ccc init` and go straight to indexing.
 
 ### CLI Reference
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ ccc search "authentication logic"       # search!
 
 The background daemon starts automatically on first use.
 
-> **Tip:** Once global settings exist (created by your first `ccc init` on the machine), `ccc index` auto-initializes new projects with default settings — you can skip `ccc init` and go straight to indexing.
+> **Tip:** You can skip `ccc init` and go straight to `ccc index` — it auto-initializes new projects with default settings. If global settings are missing too (first use on the machine), it walks you through the same model setup as `ccc init` when run interactively; non-interactive runs (scripts, hooks) still require a one-time `ccc init` first.
 
 ### CLI Reference
 

--- a/src/cocoindex_code/cli.py
+++ b/src/cocoindex_code/cli.py
@@ -76,11 +76,13 @@ def _apply_host_cwd() -> None:
 # ---------------------------------------------------------------------------
 
 
-def require_project_root() -> Path:
+def require_project_root(*, auto_init: bool = False) -> Path:
     """Find the project root by walking up from CWD.
 
     Checks global settings first (more fundamental), then project settings.
-    Exits with code 1 if either check fails.
+    With ``auto_init``, a missing project is initialized with default settings
+    instead of failing; missing global settings always exit with code 1, since
+    creating them needs the interactive model setup in ``ccc init``.
     """
     gs_path = user_settings_path()
     if not gs_path.is_file():
@@ -92,6 +94,8 @@ def require_project_root() -> Path:
         raise _typer.Exit(code=1)
     root = find_project_root(Path.cwd())
     if root is None:
+        if auto_init:
+            return _auto_init_project(Path.cwd())
         _typer.echo(
             "Error: Not in an initialized project directory.\n"
             "Run `ccc init` in your project root to get started.",
@@ -99,6 +103,24 @@ def require_project_root() -> Path:
         )
         raise _typer.Exit(code=1)
     return root
+
+
+def _auto_init_project(cwd: Path) -> Path:
+    """Create default project settings without an explicit ``ccc init``.
+
+    Anchors at the nearest parent git root when there is one, so running from
+    a repo subdirectory initializes the repo root rather than the subdirectory.
+    """
+    root = find_parent_with_marker(cwd) or cwd
+    _create_project_settings(root)
+    return root
+
+
+def _create_project_settings(root: Path) -> None:
+    """Write default project settings at *root* and gitignore the settings dir."""
+    save_project_settings(root, default_project_settings())
+    add_to_gitignore(root)
+    _typer.echo(f"Created project settings: {format_path_for_display(project_settings_path(root))}")
 
 
 _F = TypeVar("_F", bound=Callable[..., object])
@@ -599,12 +621,7 @@ def init(
             )
             raise _typer.Exit(code=1)
 
-    # Create project settings
-    save_project_settings(cwd, default_project_settings())
-    _typer.echo(f"Created project settings: {format_path_for_display(settings_file)}")
-
-    # Add to .gitignore
-    add_to_gitignore(cwd)
+    _create_project_settings(cwd)
 
     _typer.echo("You can edit the settings files to customize indexing behavior.")
     _typer.echo("Run `ccc index` to build the index.")
@@ -616,7 +633,7 @@ def index() -> None:
     """Create/update index for the codebase."""
     from . import client as _client
 
-    project_root = str(require_project_root())
+    project_root = str(require_project_root(auto_init=True))
     print_project_header(project_root)
     _run_index_with_progress(project_root)
     print_index_stats(_client.project_status(project_root))

--- a/src/cocoindex_code/cli.py
+++ b/src/cocoindex_code/cli.py
@@ -81,17 +81,22 @@ def require_project_root(*, auto_init: bool = False) -> Path:
 
     Checks global settings first (more fundamental), then project settings.
     With ``auto_init``, a missing project is initialized with default settings
-    instead of failing; missing global settings always exit with code 1, since
-    creating them needs the interactive model setup in ``ccc init``.
+    instead of failing. Missing global settings run the same interactive model
+    setup as ``ccc init`` — but only on a TTY, since picking an embedding model
+    is a consequential choice; non-interactive runs (scripts, hooks, agents)
+    still exit with code 1 rather than silently committing to a default model.
     """
     gs_path = user_settings_path()
     if not gs_path.is_file():
-        _typer.echo(
-            f"Error: Global settings not found: {format_path_for_display(gs_path)}\n"
-            "Run `ccc init` to create it with default settings.",
-            err=True,
-        )
-        raise _typer.Exit(code=1)
+        if auto_init and sys.stdin.isatty():
+            _setup_user_settings_interactive(None)
+        else:
+            _typer.echo(
+                f"Error: Global settings not found: {format_path_for_display(gs_path)}\n"
+                "Run `ccc init` to create it with default settings.",
+                err=True,
+            )
+            raise _typer.Exit(code=1)
     root = find_project_root(Path.cwd())
     if root is None:
         if auto_init:

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -51,6 +51,61 @@ def test_require_project_root_exits_when_not_initialized(
         require_project_root()
 
 
+def test_require_project_root_auto_init_at_git_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """With auto_init, a missing project is initialized at the enclosing git root."""
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    subdir = repo / "src"
+    subdir.mkdir()
+    monkeypatch.chdir(subdir)
+    settings_dir = tmp_path / "ccc_home"
+    settings_dir.mkdir()
+    (settings_dir / "global_settings.yml").write_text(
+        "embedding:\n  model: test\n  provider: litellm\n"
+    )
+    monkeypatch.setenv("COCOINDEX_CODE_DIR", str(settings_dir))
+
+    assert require_project_root(auto_init=True) == repo
+    assert (repo / ".cocoindex_code" / "settings.yml").is_file()
+    assert "/.cocoindex_code/" in (repo / ".gitignore").read_text()
+    assert "Created project settings" in capsys.readouterr().out
+
+
+def test_require_project_root_auto_init_falls_back_to_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Without a parent git root, auto_init initializes the current directory."""
+    standalone = tmp_path / "standalone"
+    standalone.mkdir()
+    monkeypatch.chdir(standalone)
+    settings_dir = tmp_path / "ccc_home"
+    settings_dir.mkdir()
+    (settings_dir / "global_settings.yml").write_text(
+        "embedding:\n  model: test\n  provider: litellm\n"
+    )
+    monkeypatch.setenv("COCOINDEX_CODE_DIR", str(settings_dir))
+
+    assert require_project_root(auto_init=True) == standalone
+    assert (standalone / ".cocoindex_code" / "settings.yml").is_file()
+
+
+def test_require_project_root_auto_init_still_requires_global_settings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """auto_init never creates global settings — those need interactive `ccc init`."""
+    standalone = tmp_path / "standalone"
+    standalone.mkdir()
+    monkeypatch.chdir(standalone)
+    monkeypatch.setenv("COCOINDEX_CODE_DIR", str(tmp_path / "no_ccc_home"))
+    from click.exceptions import Exit
+
+    with pytest.raises(Exit):
+        require_project_root(auto_init=True)
+    assert not (standalone / ".cocoindex_code").exists()
+
+
 def test_resolve_default_path_from_subdirectory(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -91,19 +91,46 @@ def test_require_project_root_auto_init_falls_back_to_cwd(
     assert (standalone / ".cocoindex_code" / "settings.yml").is_file()
 
 
-def test_require_project_root_auto_init_still_requires_global_settings(
+def test_require_project_root_auto_init_global_settings_non_tty_errors(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """auto_init never creates global settings — those need interactive `ccc init`."""
+    """Without a TTY, auto_init never creates global settings — scripts must not
+    silently commit to a default embedding model."""
     standalone = tmp_path / "standalone"
     standalone.mkdir()
     monkeypatch.chdir(standalone)
     monkeypatch.setenv("COCOINDEX_CODE_DIR", str(tmp_path / "no_ccc_home"))
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: False)
     from click.exceptions import Exit
 
     with pytest.raises(Exit):
         require_project_root(auto_init=True)
     assert not (standalone / ".cocoindex_code").exists()
+
+
+def test_require_project_root_auto_init_global_settings_tty_runs_init_setup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """On a TTY, auto_init runs the same interactive model setup as `ccc init`
+    for missing global settings, then proceeds to initialize the project."""
+    standalone = tmp_path / "standalone"
+    standalone.mkdir()
+    monkeypatch.chdir(standalone)
+    settings_dir = tmp_path / "ccc_home"
+    monkeypatch.setenv("COCOINDEX_CODE_DIR", str(settings_dir))
+    monkeypatch.setattr(cli.sys.stdin, "isatty", lambda: True)
+
+    def fake_setup(litellm_model_flag: str | None) -> None:
+        settings_dir.mkdir()
+        (settings_dir / "global_settings.yml").write_text(
+            "embedding:\n  model: test\n  provider: litellm\n"
+        )
+
+    monkeypatch.setattr(cli, "_setup_user_settings_interactive", fake_setup)
+
+    assert require_project_root(auto_init=True) == standalone
+    assert (settings_dir / "global_settings.yml").is_file()
+    assert (standalone / ".cocoindex_code" / "settings.yml").is_file()
 
 
 def test_resolve_default_path_from_subdirectory(

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -395,12 +395,17 @@ def test_session_search_refresh() -> None:
     assert "main.py" in result.output
 
 
-@pytest.mark.usefixtures("e2e_project")
-def test_session_index_not_initialized_errors() -> None:
-    """Running ``ccc index`` from uninitialized dir should error."""
-    result = runner.invoke(app, ["index"])
-    assert result.exit_code != 0
-    assert "ccc init" in result.output
+def test_session_index_auto_initializes(e2e_project: Path) -> None:
+    """Running ``ccc index`` from an uninitialized dir auto-creates project settings."""
+    result = runner.invoke(app, ["index"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    assert "Created project settings" in result.output
+    assert (e2e_project / ".cocoindex_code" / "settings.yml").is_file()
+
+    # The auto-initialized project is fully usable: search works.
+    result = runner.invoke(app, ["search", "fibonacci"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    assert "main.py" in result.output
 
 
 def test_session_subdirectory_path_default(e2e_project: Path) -> None:


### PR DESCRIPTION
## Problem

The README has claimed since 9c8a143 that `ccc index` "auto-initializes if you haven't run `ccc init` yet, so you can skip straight to indexing" — but that was never implemented. Running `ccc index` in an uninitialized project always hard-errored:

```
$ ccc index
Error: Not in an initialized project directory.
Run `ccc init` in your project root to get started.
```

## Fix

Make the code match the claim:

- `require_project_root()` gains an `auto_init` keyword (only the `index` command opts in). When project settings are missing, it creates default ones instead of failing — anchored at the nearest parent git root via `find_parent_with_marker()` (falling back to CWD), so running from a repo subdirectory initializes the repo root rather than scattering settings files.
- When **global** settings are missing too (first use on the machine), auto-init runs the same interactive model setup as `ccc init` — but only on a TTY, since picking an embedding model is a consequential choice. Non-interactive runs (scripts, hooks, agents) still exit with an error rather than silently committing to a default model.
- `init` and the auto-init path now share a `_create_project_settings()` helper (save settings + gitignore + echo), so both print the same output.
- README tip updated to describe the interactive/non-interactive split.

## Testing

- New unit tests: auto-init anchors at the git root (and writes `.gitignore`), falls back to CWD without a git root, runs the interactive model setup for missing global settings on a TTY, and still errors without a TTY (creating nothing).
- `test_session_index_not_initialized_errors` (which asserted the old hard-error) is rewritten as `test_session_index_auto_initializes`: exit 0, settings file created, and search works afterward.
- Verified end-to-end manually: `ccc index` in a fresh uninitialized directory creates settings and indexes in one shot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M4wRn5LoKRrF2mxGqdU7Fk
