### PR TITLE
fix(client): crash-aware restart of a daemon that vanished mid-session

### DIFF
--- a/src/cocoindex_code/_daemon_paths.py
+++ b/src/cocoindex_code/_daemon_paths.py
@@ -6,8 +6,11 @@ can import these without pulling in the full daemon stack.
 
 from __future__ import annotations
 
+import json
 import os
 import sys
+import time
+from dataclasses import dataclass
 from pathlib import Path
 
 from .settings import user_settings_dir
@@ -58,3 +61,50 @@ def daemon_pid_path() -> Path:
 def daemon_log_path() -> Path:
     """Return the path for the daemon's log file."""
     return daemon_runtime_dir() / "daemon.log"
+
+
+def daemon_last_exit_path() -> Path:
+    """Return the path for the daemon's graceful-exit marker file."""
+    return daemon_runtime_dir() / "last_exit"
+
+
+@dataclass
+class LastExitMarker:
+    """Record of the most recent *graceful* daemon exit.
+
+    Written by the daemon's graceful shutdown path (``StopRequest``,
+    SIGTERM/SIGINT) and removed again at the next daemon startup. A crashed
+    daemon (SIGKILL, OOM, segfault) never writes it — that absence is how the
+    client tells a crash from a graceful exit.
+    """
+
+    pid: int
+    reason: str
+    timestamp: float
+
+
+def write_last_exit_marker(pid: int, reason: str) -> None:
+    """Persist the graceful-exit marker. Best-effort — never raises."""
+    payload = json.dumps({"pid": pid, "reason": reason, "timestamp": time.time()})
+    try:
+        daemon_last_exit_path().write_text(payload)
+    except OSError:
+        pass
+
+
+def read_last_exit_marker() -> LastExitMarker | None:
+    """Read the graceful-exit marker, or None when absent/unreadable."""
+    try:
+        data = json.loads(daemon_last_exit_path().read_text())
+        return LastExitMarker(
+            pid=int(data["pid"]),
+            reason=str(data["reason"]),
+            timestamp=float(data["timestamp"]),
+        )
+    except (OSError, ValueError, KeyError, TypeError):
+        return None
+
+
+def clear_last_exit_marker() -> None:
+    """Remove the marker (daemon startup) so it always refers to the most recent exit."""
+    daemon_last_exit_path().unlink(missing_ok=True)

--- a/src/cocoindex_code/client.py
+++ b/src/cocoindex_code/client.py
@@ -139,12 +139,12 @@ def _connect_and_handshake() -> Connection:
     global _daemon_ensured, _ensured_daemon_pid, _consecutive_crash_restarts  # noqa: PLW0603
 
     try:
-        conn, resp = _raw_connect_and_handshake()
+        result = _raw_connect_and_handshake()
         _daemon_ensured = True
-        _ensured_daemon_pid = resp.pid
+        _ensured_daemon_pid = result.resp.pid
         # The daemon answered without needing a restart — any crash streak is over.
         _consecutive_crash_restarts = 0
-        return conn
+        return result.conn
     except DaemonVersionError as e:
         # `resp.ok` is False only for a real version mismatch. Once we have
         # ensured a matching daemon, a fresh version mismatch means the binary
@@ -175,10 +175,10 @@ def _connect_and_handshake() -> Connection:
     # Verify the fresh daemon is reachable
     for _attempt in range(10):
         try:
-            conn, resp = _raw_connect_and_handshake()
+            result = _raw_connect_and_handshake()
             _daemon_ensured = True
-            _ensured_daemon_pid = resp.pid
-            return conn
+            _ensured_daemon_pid = result.resp.pid
+            return result.conn
         except (ConnectionRefusedError, OSError):
             time.sleep(0.5)
 
@@ -576,7 +576,7 @@ def stop_daemon() -> None:
 
     # 1) Graceful StopRequest via socket (bypass auto-start)
     try:
-        conn, _resp = _raw_connect_and_handshake()
+        conn = _raw_connect_and_handshake().conn
         try:
             conn.send_bytes(encode_request(StopRequest()))
             conn.recv_bytes()

--- a/src/cocoindex_code/client.py
+++ b/src/cocoindex_code/client.py
@@ -16,6 +16,7 @@ import time
 from collections.abc import Callable
 from multiprocessing.connection import Client, Connection
 from pathlib import Path
+from typing import NamedTuple
 
 from ._daemon_paths import (
     connection_family,
@@ -23,6 +24,7 @@ from ._daemon_paths import (
     daemon_pid_path,
     daemon_runtime_dir,
     daemon_socket_path,
+    read_last_exit_marker,
 )
 from ._version import __version__
 from .protocol import (
@@ -64,6 +66,19 @@ logger = logging.getLogger(__name__)
 
 
 _daemon_ensured = False
+
+# PID of the daemon we last completed a handshake with. Matched against the
+# graceful-exit marker when the daemon later vanishes, to tell an expected
+# exit (e.g. `ccc daemon stop`) from a crash.
+_ensured_daemon_pid: int | None = None
+
+# Consecutive crash-restarts in this process. Reset whenever the daemon
+# answers without needing a restart; at _MAX_CONSECUTIVE_CRASH_RESTARTS we
+# stop relaunching a crash-looping daemon and surface the failure instead.
+# In-process state: it matters for the long-lived MCP server, while one-shot
+# CLI invocations get at most one crash-restart each — which is fine.
+_consecutive_crash_restarts = 0
+_MAX_CONSECUTIVE_CRASH_RESTARTS = 3
 
 # Tracks which daemon-side handshake warnings have already been surfaced to
 # the user in this process. We print each distinct warning at most once per
@@ -111,33 +126,43 @@ def _connect_and_handshake() -> Connection:
 
     Returns the open connection for the caller to send exactly one request.
 
-    Automatically starts or restarts the daemon when it is absent or running
-    with stale global settings (e.g. a ``ccc init`` retry rewrote
-    ``global_settings.yml`` after the daemon loaded it). A genuine *version*
-    mismatch after we have already reached a matching daemon means the binary
-    was replaced under us mid-session — that fails fast instead of looping on
-    restarts.
+    Automatically starts or restarts the daemon when it is absent (first call,
+    or it exited since the last request) or running with
+    stale global settings (e.g. a ``ccc init`` retry rewrote
+    ``global_settings.yml`` after the daemon loaded it). An ensured daemon
+    that vanished *without* leaving a graceful-exit marker crashed — that is
+    restarted loudly, and given up on after a few consecutive crashes (see
+    ``_handle_vanished_daemon``). A genuine *version* mismatch after we have
+    already reached a matching daemon means the binary was replaced under us
+    mid-session — that fails fast instead of looping on restarts.
     """
-    global _daemon_ensured  # noqa: PLW0603
+    global _daemon_ensured, _ensured_daemon_pid, _consecutive_crash_restarts  # noqa: PLW0603
 
     try:
-        conn = _raw_connect_and_handshake()
+        conn, resp = _raw_connect_and_handshake()
         _daemon_ensured = True
+        _ensured_daemon_pid = resp.pid
+        # The daemon answered without needing a restart — any crash streak is over.
+        _consecutive_crash_restarts = 0
         return conn
     except DaemonVersionError as e:
         # `resp.ok` is False only for a real version mismatch. Once we have
         # ensured a matching daemon, a fresh version mismatch means the binary
         # was swapped under us — fail fast. A settings-only restart request
         # (resp.ok True, but the loaded settings mtime moved) is expected;
-        # restart the daemon below so it reloads them.
+        # restart the daemon below so it reloads them. (stop_daemon sends a
+        # StopRequest, so this restart leaves a graceful-exit marker and the
+        # next connect stays silent.)
         if _daemon_ensured and not e.resp.ok:
             raise
         stop_daemon()
     except (ConnectionRefusedError, OSError):
-        # No daemon answered. Normal on the first call (start one below); if we
-        # had already ensured one it vanished mid-session — surface that.
+        # No daemon answered. Normal on the first call of this process (start
+        # one below). If we had already ensured one, decide crash vs graceful
+        # exit — a crash restarts loudly and is capped, a graceful exit (e.g.
+        # a manual stop) restarts silently.
         if _daemon_ensured:
-            raise
+            _handle_vanished_daemon()
 
     if _is_daemon_supervised():
         # Supervisor is responsible for (re)starting the daemon — just wait
@@ -150,8 +175,9 @@ def _connect_and_handshake() -> Connection:
     # Verify the fresh daemon is reachable
     for _attempt in range(10):
         try:
-            conn = _raw_connect_and_handshake()
+            conn, resp = _raw_connect_and_handshake()
             _daemon_ensured = True
+            _ensured_daemon_pid = resp.pid
             return conn
         except (ConnectionRefusedError, OSError):
             time.sleep(0.5)
@@ -159,7 +185,41 @@ def _connect_and_handshake() -> Connection:
     raise RuntimeError("Failed to connect to daemon after starting it")
 
 
-def _raw_connect_and_handshake() -> Connection:
+def _handle_vanished_daemon() -> None:
+    """Decide how to react when an ensured daemon no longer answers.
+
+    A graceful exit (``ccc daemon stop``, SIGTERM) leaves a
+    last-exit marker carrying the exiting daemon's pid; when it matches the
+    pid we handshook with, the restart is expected and silent. No marker (or
+    a marker from a different process) means the daemon *crashed*: restart
+    it, but warn on stderr, and after ``_MAX_CONSECUTIVE_CRASH_RESTARTS``
+    consecutive crashes raise instead of relaunching a crash-looping daemon.
+    """
+    global _consecutive_crash_restarts  # noqa: PLW0603
+
+    marker = read_last_exit_marker()
+    if marker is not None and marker.pid == _ensured_daemon_pid:
+        return  # graceful exit — silent transparent restart
+
+    _consecutive_crash_restarts += 1
+    if _consecutive_crash_restarts >= _MAX_CONSECUTIVE_CRASH_RESTARTS:
+        raise RuntimeError(
+            f"cocoindex-code daemon crashed {_consecutive_crash_restarts} times in a row; "
+            f"not restarting it again. Check the daemon log ({daemon_log_path()}) "
+            "or run `ccc doctor`."
+        )
+    print_warning(
+        "cocoindex-code daemon exited unexpectedly; restarting. "
+        f"See {daemon_log_path()} for details."
+    )
+
+
+class _HandshakeResult(NamedTuple):
+    conn: Connection
+    resp: HandshakeResponse
+
+
+def _raw_connect_and_handshake() -> _HandshakeResult:
     """Low-level connect + handshake without auto-start logic."""
     sock = daemon_socket_path()
     if sys.platform != "win32" and not os.path.exists(sock):
@@ -187,7 +247,7 @@ def _raw_connect_and_handshake() -> Connection:
         conn.close()
         raise DaemonVersionError(resp)
     _print_handshake_warnings(resp)
-    return conn
+    return _HandshakeResult(conn=conn, resp=resp)
 
 
 class DaemonVersionError(RuntimeError):
@@ -500,8 +560,9 @@ def stop_daemon() -> None:
 
     Escalation: StopRequest → SIGTERM → SIGKILL.
     """
-    global _daemon_ensured  # noqa: PLW0603
+    global _daemon_ensured, _ensured_daemon_pid  # noqa: PLW0603
     _daemon_ensured = False
+    _ensured_daemon_pid = None
     _surfaced_warnings.clear()
     pid_path = daemon_pid_path()
 
@@ -515,7 +576,7 @@ def stop_daemon() -> None:
 
     # 1) Graceful StopRequest via socket (bypass auto-start)
     try:
-        conn = _raw_connect_and_handshake()
+        conn, _resp = _raw_connect_and_handshake()
         try:
             conn.send_bytes(encode_request(StopRequest()))
             conn.recv_bytes()

--- a/src/cocoindex_code/daemon.py
+++ b/src/cocoindex_code/daemon.py
@@ -17,11 +17,13 @@ from pathlib import Path
 from typing import Any
 
 from ._daemon_paths import (
+    clear_last_exit_marker,
     connection_family,
     daemon_log_path,
     daemon_pid_path,
     daemon_runtime_dir,
     daemon_socket_path,
+    write_last_exit_marker,
 )
 from ._version import __version__
 from .chunking import ChunkerFn as _ChunkerFn
@@ -232,6 +234,7 @@ async def handle_connection(
                 HandshakeResponse(
                     ok=ok,
                     daemon_version=__version__,
+                    pid=os.getpid(),
                     global_settings_mtime_us=settings_mtime_us,
                     warnings=list(handshake_warnings),
                 )
@@ -590,9 +593,11 @@ def run_daemon() -> None:
         settings_env_keys = []
         embedder = None
 
-    # Write PID file
+    # Write PID file; drop the previous daemon's graceful-exit marker so the
+    # marker always refers to the most recent exit.
     pid_path = daemon_pid_path()
     pid_path.write_text(str(os.getpid()))
+    clear_last_exit_marker()
 
     # Set up logging to file
     log_path = daemon_log_path()
@@ -625,8 +630,17 @@ def run_daemon() -> None:
     loop = asyncio.new_event_loop()
     tasks: set[asyncio.Task[Any]] = set()
 
-    def _request_shutdown() -> None:
-        """Trigger daemon shutdown — called by StopRequest or signal handler."""
+    shutdown_reason: str | None = None
+
+    def _request_shutdown(reason: str) -> None:
+        """Trigger daemon shutdown — called by StopRequest or signal handler.
+
+        Records *reason* (first one wins) for the graceful-exit marker written
+        during cleanup.
+        """
+        nonlocal shutdown_reason
+        if shutdown_reason is None:
+            shutdown_reason = reason
         loop.stop()
 
     def _spawn_handler(conn: Connection) -> None:
@@ -635,7 +649,7 @@ def run_daemon() -> None:
                 conn,
                 registry,
                 start_time,
-                _request_shutdown,
+                lambda: _request_shutdown("stop_request"),
                 settings_mtime_us,
                 settings_env_keys,
                 handshake_warnings,
@@ -647,7 +661,7 @@ def run_daemon() -> None:
     # Handle signals for graceful shutdown
     try:
         for sig in (signal.SIGTERM, signal.SIGINT):
-            loop.add_signal_handler(sig, _request_shutdown)
+            loop.add_signal_handler(sig, _request_shutdown, "signal")
     except (RuntimeError, NotImplementedError):
         pass  # Not in main thread, or not supported on this platform (e.g. Windows)
 
@@ -669,6 +683,12 @@ def run_daemon() -> None:
     try:
         loop.run_forever()
     finally:
+        # 0. Record the graceful exit (StopRequest, signal). Written first so
+        #    a client that races the rest of the cleanup already sees it. A
+        #    crashed daemon never gets here — the marker's absence is how the
+        #    client detects a crash.
+        write_last_exit_marker(pid=os.getpid(), reason=shutdown_reason or "unknown")
+
         # 1. Stop accepting new connections.
         listener.close()
 

--- a/src/cocoindex_code/protocol.py
+++ b/src/cocoindex_code/protocol.py
@@ -70,6 +70,11 @@ Request = (
 class HandshakeResponse(_msgspec.Struct, tag="handshake"):
     ok: bool
     daemon_version: str
+    # The daemon's process id. The client remembers it so that, when the
+    # daemon later vanishes, the graceful-exit marker (written on shutdown
+    # with the same pid) can be matched race-free against the exact process
+    # the client was talking to — distinguishing a graceful exit from a crash.
+    pid: int
     global_settings_mtime_us: int | None = None
     # Non-fatal daemon-side warnings surfaced to the client on every handshake.
     # The client dedupes and prints them to stderr (see client._print_handshake_warnings).

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import tempfile
+from multiprocessing.connection import Connection
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -96,13 +98,13 @@ def test_connect_restarts_ensured_daemon_on_stale_settings(
     ok_resp = HandshakeResponse(ok=True, daemon_version="v1", pid=42)
     calls = {"raw": 0, "stop": 0, "start": 0}
 
-    def fake_raw() -> tuple[object, HandshakeResponse]:
+    def fake_raw() -> client._HandshakeResult:
         calls["raw"] += 1
         if calls["raw"] == 1:
             raise client.DaemonVersionError(
                 HandshakeResponse(ok=True, daemon_version="v1", pid=42, global_settings_mtime_us=1)
             )
-        return sentinel_conn, ok_resp
+        return client._HandshakeResult(conn=cast(Connection, sentinel_conn), resp=ok_resp)
 
     monkeypatch.setattr(client, "_raw_connect_and_handshake", fake_raw)
     monkeypatch.setattr(client, "stop_daemon", lambda: calls.update(stop=calls["stop"] + 1))
@@ -170,11 +172,11 @@ def _setup_vanished_daemon(
     ok_resp = HandshakeResponse(ok=True, daemon_version="v1", pid=43)
     calls = {"raw": 0, "start": 0}
 
-    def fake_raw() -> tuple[object, HandshakeResponse]:
+    def fake_raw() -> client._HandshakeResult:
         calls["raw"] += 1
         if calls["raw"] == 1:
             raise ConnectionRefusedError("daemon socket not found")
-        return sentinel_conn, ok_resp
+        return client._HandshakeResult(conn=cast(Connection, sentinel_conn), resp=ok_resp)
 
     monkeypatch.setattr(client, "_raw_connect_and_handshake", fake_raw)
     monkeypatch.setattr(client, "start_daemon", lambda: calls.update(start=calls["start"] + 1))
@@ -256,7 +258,11 @@ def test_crash_counter_resets_on_clean_connect(monkeypatch: pytest.MonkeyPatch) 
 
     sentinel_conn = object()
     ok_resp = HandshakeResponse(ok=True, daemon_version="v1", pid=7)
-    monkeypatch.setattr(client, "_raw_connect_and_handshake", lambda: (sentinel_conn, ok_resp))
+    monkeypatch.setattr(
+        client,
+        "_raw_connect_and_handshake",
+        lambda: client._HandshakeResult(conn=cast(Connection, sentinel_conn), resp=ok_resp),
+    )
 
     conn = client._connect_and_handshake()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,6 +8,8 @@ from pathlib import Path
 import pytest
 
 from cocoindex_code import client
+from cocoindex_code._daemon_paths import LastExitMarker
+from cocoindex_code.protocol import HandshakeResponse
 
 
 def test_client_connect_refuses_when_no_daemon(
@@ -46,10 +48,10 @@ def test_print_handshake_warnings_dedupes_within_process(
     monkeypatch.setattr(client, "_surfaced_warnings", set())
 
     resp1 = HandshakeResponse(
-        ok=True, daemon_version="x", warnings=["first warning", "second warning"]
+        ok=True, daemon_version="x", pid=1, warnings=["first warning", "second warning"]
     )
     resp2 = HandshakeResponse(
-        ok=True, daemon_version="x", warnings=["first warning", "third warning"]
+        ok=True, daemon_version="x", pid=1, warnings=["first warning", "third warning"]
     )
 
     client._print_handshake_warnings(resp1)
@@ -75,7 +77,7 @@ def test_print_handshake_warnings_no_warnings_prints_nothing(
     from cocoindex_code.protocol import HandshakeResponse
 
     monkeypatch.setattr(client, "_surfaced_warnings", set())
-    client._print_handshake_warnings(HandshakeResponse(ok=True, daemon_version="x"))
+    client._print_handshake_warnings(HandshakeResponse(ok=True, daemon_version="x", pid=1))
     assert capsys.readouterr().err == ""
 
 
@@ -91,15 +93,16 @@ def test_connect_restarts_ensured_daemon_on_stale_settings(
     monkeypatch.setattr(client, "_daemon_ensured", True)
 
     sentinel_conn = object()
+    ok_resp = HandshakeResponse(ok=True, daemon_version="v1", pid=42)
     calls = {"raw": 0, "stop": 0, "start": 0}
 
-    def fake_raw() -> object:
+    def fake_raw() -> tuple[object, HandshakeResponse]:
         calls["raw"] += 1
         if calls["raw"] == 1:
             raise client.DaemonVersionError(
-                HandshakeResponse(ok=True, daemon_version="v1", global_settings_mtime_us=1)
+                HandshakeResponse(ok=True, daemon_version="v1", pid=42, global_settings_mtime_us=1)
             )
-        return sentinel_conn
+        return sentinel_conn, ok_resp
 
     monkeypatch.setattr(client, "_raw_connect_and_handshake", fake_raw)
     monkeypatch.setattr(client, "stop_daemon", lambda: calls.update(stop=calls["stop"] + 1))
@@ -127,7 +130,9 @@ def test_connect_fails_fast_on_version_mismatch_after_ensured(
     started = {"start": 0}
 
     def fake_raw() -> object:
-        raise client.DaemonVersionError(HandshakeResponse(ok=False, daemon_version="other-version"))
+        raise client.DaemonVersionError(
+            HandshakeResponse(ok=False, daemon_version="other-version", pid=42)
+        )
 
     monkeypatch.setattr(client, "_raw_connect_and_handshake", fake_raw)
     monkeypatch.setattr(client, "stop_daemon", lambda: None)
@@ -140,15 +145,156 @@ def test_connect_fails_fast_on_version_mismatch_after_ensured(
     assert started["start"] == 0  # never tried to restart
 
 
+# ---------------------------------------------------------------------------
+# Vanished-daemon handling: graceful-exit marker vs crash
+# ---------------------------------------------------------------------------
+
+
+def _setup_vanished_daemon(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    marker: LastExitMarker | None,
+    ensured_pid: int = 42,
+) -> tuple[object, dict[str, int]]:
+    """Scaffolding: an ensured daemon whose next connect is refused.
+
+    ``marker`` is what ``read_last_exit_marker`` returns — a marker with
+    ``pid == ensured_pid`` simulates a graceful exit, anything else a crash.
+    """
+    monkeypatch.setattr(client, "_daemon_ensured", True)
+    monkeypatch.setattr(client, "_ensured_daemon_pid", ensured_pid)
+    monkeypatch.setattr(client, "_consecutive_crash_restarts", 0)
+    monkeypatch.setattr(client, "read_last_exit_marker", lambda: marker)
+
+    sentinel_conn = object()
+    ok_resp = HandshakeResponse(ok=True, daemon_version="v1", pid=43)
+    calls = {"raw": 0, "start": 0}
+
+    def fake_raw() -> tuple[object, HandshakeResponse]:
+        calls["raw"] += 1
+        if calls["raw"] == 1:
+            raise ConnectionRefusedError("daemon socket not found")
+        return sentinel_conn, ok_resp
+
+    monkeypatch.setattr(client, "_raw_connect_and_handshake", fake_raw)
+    monkeypatch.setattr(client, "start_daemon", lambda: calls.update(start=calls["start"] + 1))
+    monkeypatch.setattr(client, "_wait_for_daemon", lambda **_kw: None)
+    monkeypatch.setattr(client, "_is_daemon_supervised", lambda: False)
+    return sentinel_conn, calls
+
+
+def test_connect_restarts_silently_after_graceful_exit(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A graceful exit (marker with the ensured daemon's pid — e.g. a
+    manual stop) is transparently restarted with no warning.
+    """
+    marker = LastExitMarker(pid=42, reason="stop_request", timestamp=0.0)
+    sentinel_conn, calls = _setup_vanished_daemon(monkeypatch, marker=marker, ensured_pid=42)
+
+    conn = client._connect_and_handshake()
+
+    assert conn is sentinel_conn
+    assert calls["start"] == 1  # fresh daemon started
+    assert capsys.readouterr().err == ""  # ...but silently
+    assert client._consecutive_crash_restarts == 0
+
+
+def test_connect_warns_and_restarts_after_crash(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No marker means the daemon crashed: restart, but loudly."""
+    sentinel_conn, calls = _setup_vanished_daemon(monkeypatch, marker=None)
+
+    conn = client._connect_and_handshake()
+
+    assert conn is sentinel_conn
+    assert calls["start"] == 1
+    err = capsys.readouterr().err
+    assert "exited unexpectedly" in err
+    assert client._consecutive_crash_restarts == 1
+
+
+def test_connect_marker_pid_mismatch_counts_as_crash(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A marker from a *different* process is not evidence our daemon exited
+    gracefully — treat it as a crash.
+    """
+    marker = LastExitMarker(pid=999, reason="stop_request", timestamp=0.0)
+    sentinel_conn, calls = _setup_vanished_daemon(monkeypatch, marker=marker, ensured_pid=42)
+
+    conn = client._connect_and_handshake()
+
+    assert conn is sentinel_conn
+    assert calls["start"] == 1
+    assert "exited unexpectedly" in capsys.readouterr().err
+    assert client._consecutive_crash_restarts == 1
+
+
+def test_connect_gives_up_after_consecutive_crashes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The third consecutive crash raises instead of relaunching a
+    crash-looping daemon.
+    """
+    _sentinel_conn, calls = _setup_vanished_daemon(monkeypatch, marker=None)
+    monkeypatch.setattr(client, "_consecutive_crash_restarts", 2)  # two prior crashes
+
+    with pytest.raises(RuntimeError, match="crashed 3 times in a row"):
+        client._connect_and_handshake()
+    assert calls["start"] == 0  # never tried to restart
+
+
+def test_crash_counter_resets_on_clean_connect(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A daemon that answers without needing a restart ends the crash streak,
+    and its pid is remembered for future marker matching.
+    """
+    monkeypatch.setattr(client, "_daemon_ensured", True)
+    monkeypatch.setattr(client, "_ensured_daemon_pid", 42)
+    monkeypatch.setattr(client, "_consecutive_crash_restarts", 2)
+
+    sentinel_conn = object()
+    ok_resp = HandshakeResponse(ok=True, daemon_version="v1", pid=7)
+    monkeypatch.setattr(client, "_raw_connect_and_handshake", lambda: (sentinel_conn, ok_resp))
+
+    conn = client._connect_and_handshake()
+
+    assert conn is sentinel_conn
+    assert client._consecutive_crash_restarts == 0
+    assert client._ensured_daemon_pid == 7
+
+
+def test_last_exit_marker_round_trip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from cocoindex_code._daemon_paths import (
+        clear_last_exit_marker,
+        read_last_exit_marker,
+        write_last_exit_marker,
+    )
+
+    monkeypatch.setenv("COCOINDEX_CODE_RUNTIME_DIR", str(tmp_path))
+    assert read_last_exit_marker() is None
+
+    write_last_exit_marker(pid=123, reason="stop_request")
+    marker = read_last_exit_marker()
+    assert marker is not None
+    assert marker.pid == 123
+    assert marker.reason == "stop_request"
+    assert marker.timestamp > 0
+
+    clear_last_exit_marker()
+    assert read_last_exit_marker() is None
+
+
 def test_daemon_version_error_message_reflects_cause() -> None:
     """The error text matches the real cause — not always "version mismatch"."""
     from cocoindex_code.protocol import HandshakeResponse
 
-    version_err = client.DaemonVersionError(HandshakeResponse(ok=False, daemon_version="x"))
+    version_err = client.DaemonVersionError(HandshakeResponse(ok=False, daemon_version="x", pid=1))
     assert "version mismatch" in str(version_err)
 
     settings_err = client.DaemonVersionError(
-        HandshakeResponse(ok=True, daemon_version="x", global_settings_mtime_us=1)
+        HandshakeResponse(ok=True, daemon_version="x", pid=1, global_settings_mtime_us=1)
     )
     assert "stale global settings" in str(settings_err)
     assert "version mismatch" not in str(settings_err)

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -146,6 +146,8 @@ def test_daemon_starts_and_accepts_handshake(daemon_sock: str) -> None:
     conn, resp = _connect_and_handshake(daemon_sock)
     assert resp.ok is True
     assert resp.daemon_version == __version__
+    # The in-process daemon reports its (== pytest's) pid for crash detection.
+    assert resp.pid == os.getpid()
     # The session daemon uses a non-legacy model so no warnings expected.
     assert resp.warnings == []
     conn.close()

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -156,7 +156,7 @@ def test_daemon_starts_in_no_settings_mode_without_global_settings() -> None:
         # _raw_connect_and_handshake does its own handshake read — but it also
         # raises DaemonVersionError when the client-side mtime disagrees. With
         # the file absent on both sides, mtime=None matches, so handshake OK.
-        conn, _handshake = _raw_connect_and_handshake()
+        conn = _raw_connect_and_handshake().conn
         try:
             # Send a project request — should get an ErrorResponse pointing at
             # `ccc init`, not a crash.
@@ -214,7 +214,7 @@ def test_client_restarts_daemon_silently_after_graceful_exit(
 
     # Stop the daemon *without* client.stop_daemon(), which would reset
     # _daemon_ensured and hide the race under test.
-    conn, _handshake = client._raw_connect_and_handshake()
+    conn = client._raw_connect_and_handshake().conn
     try:
         conn.send_bytes(encode_request(StopRequest()))
         conn.recv_bytes()

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -8,6 +8,7 @@ with it through the per-request client functions, mirroring how ``ccc index`` /
 from __future__ import annotations
 
 import os
+import signal
 import tempfile
 import time
 from collections.abc import Iterator
@@ -154,7 +155,7 @@ def test_daemon_starts_in_no_settings_mode_without_global_settings() -> None:
         # _raw_connect_and_handshake does its own handshake read — but it also
         # raises DaemonVersionError when the client-side mtime disagrees. With
         # the file absent on both sides, mtime=None matches, so handshake OK.
-        conn = _raw_connect_and_handshake()
+        conn, _handshake = _raw_connect_and_handshake()
         try:
             # Send a project request — should get an ErrorResponse pointing at
             # `ccc init`, not a crash.
@@ -186,3 +187,101 @@ def test_daemon_env_response_includes_host_path_mappings(
     resp = client.daemon_env()
     assert hasattr(resp, "host_path_mappings")
     assert resp.host_path_mappings == []
+
+
+def test_client_restarts_daemon_silently_after_graceful_exit(
+    e2e_daemon: tuple[str, Path],
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """After a successful request (``_daemon_ensured`` True), a daemon that
+    exits gracefully (StopRequest) leaves a graceful-exit marker and is
+    transparently restarted by the next request, with no crash warning.
+    The fresh daemon removes the marker at startup.
+
+    NOTE: keep this test near the end of the module — it stops the shared
+    daemon and relies on the client to bring a fresh one back up.
+    """
+    from cocoindex_code._daemon_paths import daemon_last_exit_path, read_last_exit_marker
+    from cocoindex_code.protocol import StopRequest, encode_request
+
+    # Establish a session: this sets client._daemon_ensured = True.
+    resp = client.daemon_status()
+    assert resp.version == __version__
+    assert client._daemon_ensured is True
+    daemon_pid = client._ensured_daemon_pid
+    assert daemon_pid is not None
+
+    # Stop the daemon *without* client.stop_daemon(), which would reset
+    # _daemon_ensured and hide the race under test.
+    conn, _handshake = client._raw_connect_and_handshake()
+    try:
+        conn.send_bytes(encode_request(StopRequest()))
+        conn.recv_bytes()
+    finally:
+        conn.close()
+    assert client._wait_for_daemon_exit(timeout=10.0), "daemon did not exit"
+
+    # The graceful exit left a marker with the stopped daemon's pid and reason.
+    marker = read_last_exit_marker()
+    assert marker is not None
+    assert marker.pid == daemon_pid
+    assert marker.reason == "stop_request"
+
+    # The next request must transparently restart the daemon and succeed —
+    # silently, since the exit was graceful.
+    capsys.readouterr()  # drain anything printed so far
+    resp2 = client.daemon_status()
+    assert resp2.version == __version__
+    assert "exited unexpectedly" not in capsys.readouterr().err
+
+    # The fresh daemon removed the marker at startup.
+    assert not daemon_last_exit_path().exists()
+
+
+def test_client_warns_and_restarts_after_daemon_crash(
+    e2e_daemon: tuple[str, Path],
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A SIGKILLed daemon leaves no graceful-exit marker; the next request
+    warns on stderr but still succeeds via a restart.
+
+    NOTE: keep this test last in the module — it kills the shared daemon and
+    relies on the client to bring a fresh one back up.
+    """
+    from multiprocessing.connection import Client as _RawClient
+
+    from cocoindex_code._daemon_paths import connection_family, daemon_last_exit_path
+
+    monkeypatch.setattr(client, "_consecutive_crash_restarts", 0)
+
+    # Establish a session and remember the daemon's pid from the handshake.
+    resp = client.daemon_status()
+    assert resp.version == __version__
+    daemon_pid = client._ensured_daemon_pid
+    assert daemon_pid is not None
+
+    os.kill(daemon_pid, signal.SIGKILL)
+
+    # Wait until the listener is actually gone (the socket file lingers after
+    # SIGKILL, but connecting to it starts failing once the process died).
+    sock_path, _ = e2e_daemon
+    deadline = time.monotonic() + 10
+    while time.monotonic() < deadline:
+        try:
+            probe = _RawClient(sock_path, family=connection_family())
+            probe.close()
+            time.sleep(0.1)
+        except OSError:
+            break
+    else:
+        raise TimeoutError("daemon listener still up after SIGKILL")
+
+    assert not daemon_last_exit_path().exists(), "a crash must not leave a marker"
+
+    # The next request warns but still succeeds via restart.
+    capsys.readouterr()  # drain
+    resp2 = client.daemon_status()
+    assert resp2.version == __version__
+    assert "exited unexpectedly" in capsys.readouterr().err
+    assert client._consecutive_crash_restarts == 1

--- a/tests/test_e2e_daemon.py
+++ b/tests/test_e2e_daemon.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import signal
+import sys
 import tempfile
 import time
 from collections.abc import Iterator
@@ -261,7 +262,12 @@ def test_client_warns_and_restarts_after_daemon_crash(
     daemon_pid = client._ensured_daemon_pid
     assert daemon_pid is not None
 
-    os.kill(daemon_pid, signal.SIGKILL)
+    if sys.platform == "win32":
+        # No SIGKILL on Windows; os.kill with any non-CTRL signal calls
+        # TerminateProcess, which is equally abrupt (no handlers run).
+        os.kill(daemon_pid, signal.SIGTERM)
+    else:
+        os.kill(daemon_pid, signal.SIGKILL)
 
     # Wait until the listener is actually gone (the socket file lingers after
     # SIGKILL, but connecting to it starts failing once the process died).

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -13,6 +13,7 @@ from cocoindex_code.protocol import (
     DoctorResponse,
     ErrorResponse,
     HandshakeRequest,
+    HandshakeResponse,
     IndexingProgress,
     IndexProgressUpdate,
     IndexRequest,
@@ -42,6 +43,15 @@ def test_encode_decode_handshake_request() -> None:
     decoded = decode_request(data)
     assert isinstance(decoded, HandshakeRequest)
     assert decoded.version == "1.0.0"
+
+
+def test_encode_decode_handshake_response_with_pid() -> None:
+    resp = HandshakeResponse(ok=True, daemon_version="1.0.0", pid=4242)
+    decoded = decode_response(encode_response(resp))
+    assert isinstance(decoded, HandshakeResponse)
+    assert decoded.ok is True
+    assert decoded.daemon_version == "1.0.0"
+    assert decoded.pid == 4242
 
 
 def test_encode_decode_search_request_with_defaults() -> None:


### PR DESCRIPTION
## Summary

Today, when the background daemon disappears mid-session, clients handle it badly in both directions: a long-lived MCP session hard-fails on its next request ("daemon vanished"), while a daemon that *crashes* on startup or under load can be silently relaunched again and again with no signal to the user that anything is wrong.

This PR teaches the client to tell an **expected exit from a crash**, and to react accordingly:

- The daemon now writes a `last_exit` marker file (`{pid, reason, timestamp}`) on every graceful shutdown (`StopRequest`, SIGTERM/SIGINT) and clears it on the next startup. A crashed daemon (SIGKILL, OOM, segfault) never writes it — that absence is the signal.
- `HandshakeResponse` now carries the daemon's `pid`, so the client knows exactly which process it was talking to and can match the marker race-free.
- On a vanished daemon: marker matches → **silent transparent restart**; no marker / pid mismatch → the daemon crashed, so restart **once, loudly** (stderr warning pointing at the daemon log), with a cap of 3 consecutive crash-restarts before giving up with a pointer to `daemon.log` / `ccc doctor` — the systemd `StartLimitBurst` pattern. The counter resets once a handshake finds a healthy daemon without needing a restart.
- The existing version-mismatch fail-fast and the settings-mtime restart flow are unchanged (the latter stays silent, since `ccc daemon stop` leaves a graceful marker).

This is primarily **foundation for the daemon idle-timeout PR** (which follows, stacked on this one): idle-exit only works if clients can transparently and safely revive the daemon. But it's worth having on its own — it fixes the mid-session hard failure and stops crashy daemons from being relaunched invisibly.

## Tests

Marker and handshake-pid round-trips, unit tests for all four vanished-daemon classification branches, E2E graceful restart (correct reason/pid, no warning, marker cleared on next startup), and an E2E SIGKILL crash (warns on stderr, restarts, request succeeds). The crash test guards the kill on `sys.platform` (Windows has no `SIGKILL`; it uses `SIGTERM`, which `os.kill` implements via `TerminateProcess` — equally abrupt, no marker written), keeping mypy green on the Windows CI job. Full suite: 241 passed, mypy and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

