### PR TITLE
feat(cli): add --json flag to ccc search

### DIFF
--- a/src/cocoindex_code/cli.py
+++ b/src/cocoindex_code/cli.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, TypeVar
 
+import msgspec as _msgspec
 import typer as _typer
 
 if TYPE_CHECKING:
@@ -631,6 +632,7 @@ def search(
     offset: int = _typer.Option(0, "--offset", help="Number of results to skip"),
     limit: int = _typer.Option(10, "--limit", help="Maximum results to return"),
     refresh: bool = _typer.Option(False, "--refresh", help="Refresh index before searching"),
+    json_output: bool = _typer.Option(False, "--json", help="Output results as JSON"),
 ) -> None:
     """Semantic search across the codebase."""
     project_root = str(require_project_root())
@@ -656,7 +658,14 @@ def search(
         limit=limit,
         offset=offset,
     )
-    print_search_results(resp)
+    if json_output:
+        sys.stdout.buffer.write(_msgspec.json.encode(resp))
+        sys.stdout.buffer.write(b"\n")
+        sys.stdout.buffer.flush()
+        if not resp.success:
+            raise _typer.Exit(code=1)
+    else:
+        print_search_results(resp)
 
 
 @app.command()

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -8,6 +8,7 @@ commands through typer's CliRunner.
 
 from __future__ import annotations
 
+import json
 import os
 import tempfile
 from collections.abc import Iterator
@@ -393,6 +394,30 @@ def test_session_search_refresh() -> None:
     result = runner.invoke(app, ["search", "--refresh", "fibonacci"], catch_exceptions=False)
     assert result.exit_code == 0, result.output
     assert "main.py" in result.output
+
+
+def test_session_search_json_output(e2e_project: Path) -> None:
+    """`ccc search --json` emits the SearchResponse as parseable JSON on stdout."""
+    runner.invoke(app, ["init"], catch_exceptions=False)
+    runner.invoke(app, ["index"], catch_exceptions=False)
+
+    result = runner.invoke(app, ["search", "fibonacci", "--json"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["success"] is True
+    assert payload["results"], "expected at least one result"
+    top = payload["results"][0]
+    assert {"file_path", "language", "content", "start_line", "end_line", "score"} <= top.keys()
+    assert isinstance(top["score"], float)
+    assert any("main.py" in r["file_path"] for r in payload["results"])
+
+    # --json --refresh composes: index progress goes to stderr, stdout stays pure JSON.
+    result = runner.invoke(
+        app, ["search", "fibonacci", "--json", "--refresh"], catch_exceptions=False
+    )
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["success"] is True
 
 
 @pytest.mark.usefixtures("e2e_project")


### PR DESCRIPTION
## Summary

Adds a `--json` flag to `ccc search` that emits the full `SearchResponse` as JSON on stdout, making search results consumable by scripts and tool integrations.

Motivation: I'm building an [Obsidian plugin](https://github.com/junzh0u/obsidian-ccc-search) that gives a vault semantic search by shelling out to `ccc search --json` per query. With machine-readable output, an integration needs no MCP SDK, no persistent child process, and no protocol handling — just spawn, parse, render. Warm-daemon latency of a full CLI invocation is ~100–160 ms, so per-keystroke shell-out is practical behind a small debounce. Any other editor integration or shell script gets the same benefit.

Details:

- The response is serialized with `msgspec.json.encode` (msgspec is already the IPC dependency), so the JSON shape mirrors `protocol.py` exactly: `success`, `results[]` (`file_path`, `language`, `content`, `start_line`, `end_line`, `score`), `total_returned`, `offset`, `message` — plus the struct tag `"type": "search"`.
- On failure the JSON is still emitted (machine-readable `message`) and the command exits 1, so callers get structured errors without scraping stderr.
- `--json --refresh` composes cleanly: the wait spinner and index-progress UI already render to a stderr `rich.Console`, so stdout stays pure JSON. Verified in the test.

## Tests

New e2e test `test_session_search_json_output`: parses stdout as JSON, asserts success and the full field set, float scores, and that `--json --refresh` keeps stdout uncontaminated. Full suite: 233 passed; ruff and format clean. (`mypy .` reports 2 pre-existing errors in `scripts/find_best_models.py` that exist on `main` and are untouched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
