### PR TITLE
docs: slim SECURITY.md to a scope shim over the org policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,26 +1,11 @@
-# Security Policy for CocoIndex
+# Security Policy
 
-## Reporting a Vulnerability
-If you discover a security vulnerability in CocoIndex, please report it responsibly to our security team:
+Report vulnerabilities to **security@cocoindex.io** — please do not open
+public issues. Include a description, reproduction steps, and any relevant
+logs or proof-of-concept.
 
-**Email:** [security@cocoindex.io](mailto:security@cocoindex.io)
+Process, response SLAs, and disclosure terms are defined in the
+[CocoIndex organization security policy](https://github.com/cocoindex-io/.github/blob/main/SECURITY.md).
 
-⚠️ Please do not file GitHub issues for security vulnerabilities as they are public! ⚠️
-
-Please provide:
-- A detailed description of the vulnerability
-- Steps to reproduce the issue
-- Any relevant logs, screenshots, or proof-of-concept code
-
-We will acknowledge your report promptly and work with you to resolve the issue.
-
-## Scope
-This policy covers security issues related to CocoIndex open-source software.
-
-## Response & Disclosure
-- We aim to respond as soon as we can.
-- Security fixes will be released as soon as practical after verification.
-
----
-
-Thank you for helping us keep CocoIndex secure!
+**Scope:** CocoIndex Code (open source) — this repository and the PyPI
+package `cocoindex-code`. Security fixes land in the latest release.


### PR DESCRIPTION
## Summary
- Reporting process/SLAs/disclosure now live once in the [organization security policy](https://github.com/cocoindex-io/.github/blob/main/SECURITY.md); this file keeps the contact and this repo's scope (PyPI `cocoindex-code`). Replaces the generic template.

## Test plan
Docs-only; CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)