### PR TITLE
ci: add gitleaks secret-scanning pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,6 +8,12 @@ repos:
       - id: check-added-large-files
       - id: check-merge-conflict
 
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        # Scans the staged diff for hardcoded secrets before each commit.
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.9.1
     hooks:


### PR DESCRIPTION
## Summary
- Same gitleaks hook (pinned v8.30.1) as the other product repos; closes the last gap in commit-time secret scanning coverage. Pre-add full-history scan: 239 commits, clean. GitHub secret scanning + push protection also enabled on this repo today.

## Test plan
CI — prek installs and runs the hook on the runners.

🤖 Generated with [Claude Code](https://claude.com/claude-code)