### PR TITLE
feat(cli): add `ccc version`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ The daemon idle-exits after `daemon.idle_timeout_minutes` (default 180, 0 = neve
 
 **`server.py`** — FastMCP wrapper that delegates `search` calls to the daemon client. Also contains the legacy `main()` entry point (`cocoindex-code` command) for backward-compatible env-var-based configuration.
 
-**`cli.py`** — Typer app with `ccc` subcommands (`init`, `index`, `search`, `grep`, `status`, `reset`, `doctor`, `mcp`, `daemon status/restart/stop`). CLI logic only — delegates to `client.py` or `grep.py`.
+**`cli.py`** — Typer app with `ccc` subcommands (`init`, `index`, `search`, `grep`, `status`, `reset`, `doctor`, `mcp`, `version`, `daemon status/restart/stop`). CLI logic only — delegates to `client.py` or `grep.py`.
 
 **`grep.py`** — Structural code search (`ccc grep`) using CocoIndex's `code_match`. Runs entirely locally with no daemon or index. Matches in parallel, streams results per file.
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ The background daemon starts automatically on first use.
 | `ccc mcp` | Run as MCP server in stdio mode |
 | `ccc doctor` | Run diagnostics — checks settings, daemon, model, file matching, and index health |
 | `ccc reset` | Delete index databases. `--all` also removes settings. `-f` skips confirmation. |
+| `ccc version` | Print the CLI version |
 | `ccc daemon status` | Show daemon version, uptime, and loaded projects |
 | `ccc daemon restart` | Restart the background daemon |
 | `ccc daemon stop` | Stop the daemon |

--- a/src/cocoindex_code/cli.py
+++ b/src/cocoindex_code/cli.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         SearchResponse,
     )
 
+from ._version import __version__
 from .settings import (
     DEFAULT_ST_MODEL,
     EmbeddingSettings,
@@ -1118,6 +1119,12 @@ def daemon_stop() -> None:
         _typer.echo("Warning: daemon may not have stopped cleanly.", err=True)
     else:
         _typer.echo("Daemon stopped.")
+
+
+@app.command()
+def version() -> None:
+    """Print the CLI version."""
+    _typer.echo(__version__)
 
 
 @app.command("run-daemon", hidden=True)

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -289,6 +289,42 @@ def test_apply_host_cwd_noop_when_unset(
 
 
 # ---------------------------------------------------------------------------
+# ccc version
+# ---------------------------------------------------------------------------
+
+
+def test_version_prints_client_version() -> None:
+    """`ccc version` reports the client version and exits 0."""
+    from typer.testing import CliRunner
+
+    from cocoindex_code._version import __version__
+    from cocoindex_code.cli import app
+
+    result = CliRunner().invoke(app, ["version"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == __version__
+
+
+def test_version_works_outside_a_project(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No project discovery, no daemon, no settings needed."""
+    from typer.testing import CliRunner
+
+    from cocoindex_code._version import __version__
+    from cocoindex_code.cli import app
+
+    standalone = tmp_path / "not-a-project"
+    standalone.mkdir()
+    monkeypatch.chdir(standalone)
+    monkeypatch.setenv("COCOINDEX_CODE_DIR", str(tmp_path / "no-such-home"))
+
+    result = CliRunner().invoke(app, ["version"], catch_exceptions=False)
+
+    assert result.exit_code == 0
+    assert result.stdout.strip() == __version__
+
+
+# ---------------------------------------------------------------------------
 # ccc init — auto-populate indexing_params / query_params from curated table
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Adds `ccc version`, which prints the CLI version.

Today the version is only reachable through `ccc daemon status` or `ccc doctor`, and both report it by connecting to the daemon. That leaves no answer to "what version are you on?" for the case where it matters most — a user whose daemon won't start, filing a bug. `ccc version` answers offline: no project discovery, no settings, no daemon.

It reads the same `_version.__version__` the daemon handshake compares against, so the CLI and the version check can't drift apart.

## Try it

```
$ ccc version
0.2.40.dev1+gbeba2cfc8
```

Works from any directory — no initialized project, no global settings, no running daemon required. It shows up in the top-level help alongside the rest:

```
$ ccc --help
╭─ Commands ───────────────────────────────────────────────────────────────────╮
│ init     Initialize a project for cocoindex-code.                            │
│ index    Create/update index for the codebase.                               │
│ search   Semantic search across the codebase.                                │
│ grep     Structurally grep code by example (no index or daemon required).    │
│ status   Show project status.                                                │
│ reset    Reset project databases and optionally remove settings.             │
│ doctor   Check system health and report issues.                              │
│ mcp      Run as MCP server (stdio mode).                                     │
│ version  Print the CLI version.                                              │
│ daemon   Manage the daemon process.                                          │
╰──────────────────────────────────────────────────────────────────────────────╯
```

## Operational impact

None. Purely additive — a new subcommand, no change to existing commands, settings, protocol, or on-disk state. No migration. The daemon's version reporting stays exactly where it was in `ccc daemon status` and `ccc doctor`; this reports the client's, which can legitimately differ from a running daemon's.

Docs updated: README command table and the CLAUDE.md subcommand list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
