### PR TITLE
fix(cli): handle unencodable search results

### DIFF
--- a/src/cocoindex_code/cli.py
+++ b/src/cocoindex_code/cli.py
@@ -195,6 +195,15 @@ def print_index_stats(status: ProjectStatusResponse) -> None:
             _typer.echo(f"    {lang}: {count} chunks")
 
 
+def _echo_search_text(text: str) -> None:
+    """Echo result text, replacing characters unsupported by the console codec."""
+    try:
+        _typer.echo(text)
+    except UnicodeEncodeError as error:
+        safe_text = text.encode(error.encoding, errors="replace").decode(error.encoding)
+        _typer.echo(safe_text)
+
+
 def print_search_results(response: SearchResponse) -> None:
     """Print formatted search results."""
     if not response.success:
@@ -207,8 +216,8 @@ def print_search_results(response: SearchResponse) -> None:
 
     for i, r in enumerate(response.results, 1):
         _typer.echo(f"\n--- Result {i} (score: {r.score:.3f}) ---")
-        _typer.echo(f"File: {r.file_path}:{r.start_line}-{r.end_line} [{r.language}]")
-        _typer.echo(r.content)
+        _echo_search_text(f"File: {r.file_path}:{r.start_line}-{r.end_line} [{r.language}]")
+        _echo_search_text(r.content)
 
 
 def _run_index_with_progress(project_root: str) -> None:

--- a/tests/test_cli_helpers.py
+++ b/tests/test_cli_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,37 @@ from cocoindex_code.cli import (
     require_project_root,
     resolve_default_path,
 )
+from cocoindex_code.protocol import SearchResponse, SearchResult
+
+
+def test_print_search_results_replaces_unencodable_console_characters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Search output stays usable when the console cannot encode a result."""
+    raw_output = io.BytesIO()
+    gbk_stdout = io.TextIOWrapper(raw_output, encoding="gbk", errors="strict")
+    monkeypatch.setattr(cli.sys, "stdout", gbk_stdout)
+    response = SearchResponse(
+        success=True,
+        results=[
+            SearchResult(
+                file_path="notes↔.md",
+                language="markdown",
+                content="可编码内容: left ↔ right",
+                start_line=1,
+                end_line=1,
+                score=0.9,
+            )
+        ],
+    )
+
+    cli.print_search_results(response)
+    gbk_stdout.flush()
+
+    output = raw_output.getvalue().decode("gbk")
+    assert "可编码内容" in output
+    assert "File: notes?.md" in output
+    assert "left ? right" in output
 
 
 def test_require_project_root_success(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- fall back to replacement characters when search result metadata or content cannot be encoded by the console
- preserve text that the active console encoding supports
- cover file paths and result content with a strict GBK output regression

Addresses the GBK console-output failure described in https://github.com/cocoindex-io/cocoindex-code/issues/166. The separate stale-daemon environment problem remains out of scope.

## Testing

- `.venv/bin/python -m pytest tests/test_cli_helpers.py::test_print_search_results_replaces_unencodable_console_characters -q`
- `.venv/bin/python -m pytest tests/test_cli_helpers.py -q` (25 passed)
- `.venv/bin/ruff check src/cocoindex_code/cli.py tests/test_cli_helpers.py`
- `.venv/bin/ruff format --check src/cocoindex_code/cli.py tests/test_cli_helpers.py`
- `.venv/bin/python -m mypy src tests`
- `uv build --offline`

The full developer suite is not reported as passing locally: its sentence-transformers dependency resolves to torch 2.13, which has no Intel macOS wheel. The focused CLI suite, strict static checks, offline package build, and GBK-specific regression all pass.