### PR TITLE
feat(settings): add max_file_size to filter oversized files

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,8 @@ exclude_patterns:
   - "**/dist"
   # ...
 
+max_file_size: 500KB       # skip files larger than this (default: no limit)
+
 language_overrides:
   - ext: inc               # treat .inc files as PHP
     lang: php
@@ -582,7 +584,14 @@ chunkers:
 
 > `.cocoindex_code/` is automatically added to `.gitignore` during init.
 
-After editing `include_patterns`, `exclude_patterns`, or `language_overrides`:
+`max_file_size` keeps bundled or generated files out of the index without having
+to enumerate them in `exclude_patterns`. It accepts a plain byte count
+(`1048576`) or a size with a binary unit suffix: `B`, `KB`, `MB`, `GB`
+(case-insensitive, so `500KB` and `500 kb` are the same). The limit is
+inclusive, and omitting the key indexes files of any size. It applies wherever
+project file matching does, so `ccc grep` skips the same files.
+
+After editing `include_patterns`, `exclude_patterns`, `max_file_size`, or `language_overrides`:
 
 - Run `ccc doctor` to preview which files match.
 - Run `ccc index` or `ccc search --refresh ...` to update the existing index.

--- a/src/cocoindex_code/file_walk.py
+++ b/src/cocoindex_code/file_walk.py
@@ -120,6 +120,33 @@ class GitignoreAwareMatcher(FilePathMatcher):
         return self._delegate.is_file_included(path)
 
 
+class SizeLimitedMatcher(FilePathMatcher):
+    """Wraps another matcher and drops files larger than ``max_bytes``.
+
+    The matcher protocol only sees paths relative to the project root, so this
+    resolves each candidate against ``project_root`` to stat it. Files that
+    cannot be stat'd (a broken symlink, a race with a delete) are left to the
+    delegate rather than silently dropped, since a size limit should not be the
+    thing that decides an unreadable file's fate.
+    """
+
+    def __init__(self, delegate: FilePathMatcher, project_root: Path, max_bytes: int) -> None:
+        self._delegate = delegate
+        self._root = project_root
+        self._max_bytes = max_bytes
+
+    def is_dir_included(self, path: PurePath) -> bool:
+        return self._delegate.is_dir_included(path)
+
+    def is_file_included(self, path: PurePath) -> bool:
+        if not self._delegate.is_file_included(path):
+            return False
+        try:
+            return (self._root / path).stat().st_size <= self._max_bytes
+        except OSError:
+            return True
+
+
 def find_git_root(start: Path) -> Path | None:
     """Walk up from ``start`` to the nearest directory holding a ``.git`` entry — a
     directory for a normal repo, or a *file* for a submodule or linked worktree.
@@ -140,14 +167,21 @@ def build_matcher(
     project_root: Path,
     included_patterns: list[str],
     excluded_patterns: list[str],
+    max_file_size: int | None = None,
 ) -> FilePathMatcher:
     """Build the project's file matcher: include/exclude globs plus nested
-    ``.gitignore`` awareness anchored at ``project_root``."""
+    ``.gitignore`` awareness anchored at ``project_root``, and an optional
+    ``max_file_size`` cap in bytes."""
     base_matcher = PatternFilePathMatcher(
         included_patterns=included_patterns,
         excluded_patterns=excluded_patterns,
     )
-    return GitignoreAwareMatcher(base_matcher, load_gitignore_spec(project_root), project_root)
+    matcher: FilePathMatcher = GitignoreAwareMatcher(
+        base_matcher, load_gitignore_spec(project_root), project_root
+    )
+    if max_file_size is not None:
+        matcher = SizeLimitedMatcher(matcher, project_root, max_file_size)
+    return matcher
 
 
 def iter_included_files(

--- a/src/cocoindex_code/grep.py
+++ b/src/cocoindex_code/grep.py
@@ -214,17 +214,19 @@ def _iter_targets(req: GrepRequest, compiler: _PatternCompiler) -> Iterator[_Tar
     if project_root is not None:
         ps = load_project_settings(project_root)
         included, excluded = ps.include_patterns, ps.exclude_patterns
+        max_file_size = ps.max_file_size
         ext_overrides = {f".{lo.ext}": lo.lang for lo in ps.language_overrides}
         base = project_root
     else:
         included = list(DEFAULT_INCLUDED_PATTERNS)
         excluded = list(DEFAULT_EXCLUDED_PATTERNS)
         ext_overrides = {}
+        max_file_size = None
         # Anchor at the enclosing git repo so grepping a subdirectory still honors the
         # repo-root (and intervening) .gitignore; fall back to the target dir itself.
         base = find_git_root(root) or root
 
-    matcher = build_matcher(base, included, excluded)
+    matcher = build_matcher(base, included, excluded, max_file_size)
     path_filter = (
         PatternFilePathMatcher(included_patterns=[req.path_glob]) if req.path_glob else None
     )

--- a/src/cocoindex_code/indexer.py
+++ b/src/cocoindex_code/indexer.py
@@ -110,7 +110,9 @@ async def indexer_main() -> None:
         ),
     )
 
-    matcher = build_matcher(project_root, ps.include_patterns, ps.exclude_patterns)
+    matcher = build_matcher(
+        project_root, ps.include_patterns, ps.exclude_patterns, ps.max_file_size
+    )
 
     files = localfs.walk_dir(
         CODEBASE_DIR,

--- a/src/cocoindex_code/settings.py
+++ b/src/cocoindex_code/settings.py
@@ -137,6 +137,8 @@ class ProjectSettings:
     exclude_patterns: list[str] = field(default_factory=lambda: list(DEFAULT_EXCLUDED_PATTERNS))
     language_overrides: list[LanguageOverride] = field(default_factory=list)
     chunkers: list[ChunkerMapping] = field(default_factory=list)
+    #: Files larger than this many bytes are excluded. ``None`` means no limit.
+    max_file_size: int | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -476,11 +478,57 @@ def _user_settings_from_dict(d: dict[str, Any]) -> UserSettings:
     return UserSettings(embedding=embedding, envs=envs, daemon=daemon)
 
 
+_SIZE_UNITS: dict[str, int] = {
+    "B": 1,
+    "KB": 1024,
+    "MB": 1024**2,
+    "GB": 1024**3,
+}
+
+
+def parse_file_size(value: Any) -> int:
+    """Parse a ``max_file_size`` value into bytes.
+
+    Accepts a plain number of bytes (``1048576``) or a string with an optional
+    unit suffix (``500KB``, ``1.5 MB``, ``2048``). Units are binary (1KB = 1024
+    bytes) and case-insensitive.
+    """
+    if isinstance(value, bool):  # bool is an int subclass; reject it explicitly.
+        raise ValueError(f"invalid max_file_size: {value!r}")
+    if isinstance(value, int):
+        size = value
+    elif isinstance(value, float):
+        size = int(value)
+    elif isinstance(value, str):
+        text = value.strip().upper()
+        if not text:
+            raise ValueError("invalid max_file_size: empty value")
+        for suffix in ("GB", "MB", "KB", "B"):
+            if text.endswith(suffix):
+                number = text[: -len(suffix)].strip()
+                multiplier = _SIZE_UNITS[suffix]
+                break
+        else:
+            number, multiplier = text, 1
+        try:
+            size = int(float(number) * multiplier)
+        except ValueError as exc:
+            raise ValueError(f"invalid max_file_size: {value!r}") from exc
+    else:
+        raise ValueError(f"invalid max_file_size: {value!r}")
+
+    if size <= 0:
+        raise ValueError(f"max_file_size must be positive, got {value!r}")
+    return size
+
+
 def _project_settings_to_dict(settings: ProjectSettings) -> dict[str, Any]:
     d: dict[str, Any] = {
         "include_patterns": settings.include_patterns,
         "exclude_patterns": settings.exclude_patterns,
     }
+    if settings.max_file_size is not None:
+        d["max_file_size"] = settings.max_file_size
     if settings.language_overrides:
         d["language_overrides"] = [
             {"ext": lo.ext, "lang": lo.lang} for lo in settings.language_overrides
@@ -495,11 +543,14 @@ def _project_settings_from_dict(d: dict[str, Any]) -> ProjectSettings:
         LanguageOverride(ext=lo["ext"], lang=lo["lang"]) for lo in d.get("language_overrides", [])
     ]
     chunkers = [ChunkerMapping(ext=cm["ext"], module=cm["module"]) for cm in d.get("chunkers", [])]
+    raw_max_size = d.get("max_file_size")
+    max_file_size = None if raw_max_size is None else parse_file_size(raw_max_size)
     return ProjectSettings(
         include_patterns=d.get("include_patterns", list(DEFAULT_INCLUDED_PATTERNS)),
         exclude_patterns=d.get("exclude_patterns", list(DEFAULT_EXCLUDED_PATTERNS)),
         language_overrides=overrides,
         chunkers=chunkers,
+        max_file_size=max_file_size,
     )
 
 

--- a/tests/test_file_walk.py
+++ b/tests/test_file_walk.py
@@ -2,6 +2,8 @@
 
 from pathlib import Path
 
+from cocoindex.resources.file import FilePathMatcher
+
 from cocoindex_code.file_walk import build_matcher, iter_included_files
 
 
@@ -49,8 +51,8 @@ def test_max_file_size_excludes_large_files(tmp_path: Path) -> None:
     unlimited = build_matcher(tmp_path, ["**/*.py"], [])
     capped = build_matcher(tmp_path, ["**/*.py"], [], max_file_size=100)
 
-    def walked(matcher: object) -> set[str]:
-        return {rel.as_posix() for _abs, rel in iter_included_files(tmp_path, tmp_path, matcher)}  # type: ignore[arg-type]
+    def walked(matcher: FilePathMatcher) -> set[str]:
+        return {rel.as_posix() for _abs, rel in iter_included_files(tmp_path, tmp_path, matcher)}
 
     assert walked(unlimited) == {"small.py", "bundle.py"}
     assert walked(capped) == {"small.py"}

--- a/tests/test_file_walk.py
+++ b/tests/test_file_walk.py
@@ -39,3 +39,39 @@ def test_inverted_gitignore_keeps_source_directories_traversable(tmp_path: Path)
     }
 
     assert included == {"Root.cpp", "Engine/Source/kept.cpp", "Engine/Source/kept.h"}
+
+
+def test_max_file_size_excludes_large_files(tmp_path: Path) -> None:
+    """A size cap drops oversized files while leaving the rest of the walk intact."""
+    (tmp_path / "small.py").write_text("x = 1\n")
+    (tmp_path / "bundle.py").write_text("# padding\n" * 500)
+
+    unlimited = build_matcher(tmp_path, ["**/*.py"], [])
+    capped = build_matcher(tmp_path, ["**/*.py"], [], max_file_size=100)
+
+    def walked(matcher: object) -> set[str]:
+        return {rel.as_posix() for _abs, rel in iter_included_files(tmp_path, tmp_path, matcher)}  # type: ignore[arg-type]
+
+    assert walked(unlimited) == {"small.py", "bundle.py"}
+    assert walked(capped) == {"small.py"}
+
+
+def test_max_file_size_keeps_files_at_the_limit(tmp_path: Path) -> None:
+    """The cap is inclusive, so a file of exactly max_file_size bytes is kept."""
+    (tmp_path / "exact.py").write_bytes(b"a" * 64)
+    (tmp_path / "over.py").write_bytes(b"a" * 65)
+
+    matcher = build_matcher(tmp_path, ["**/*.py"], [], max_file_size=64)
+    walked = {rel.as_posix() for _abs, rel in iter_included_files(tmp_path, tmp_path, matcher)}
+
+    assert walked == {"exact.py"}
+
+
+def test_max_file_size_keeps_unstattable_files(tmp_path: Path) -> None:
+    """A broken symlink cannot be sized, so the size cap leaves the decision alone."""
+    (tmp_path / "broken.py").symlink_to(tmp_path / "missing.py")
+
+    matcher = build_matcher(tmp_path, ["**/*.py"], [], max_file_size=1)
+    walked = {rel.as_posix() for _abs, rel in iter_included_files(tmp_path, tmp_path, matcher)}
+
+    assert walked == {"broken.py"}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -30,6 +30,7 @@ from cocoindex_code.settings import (
     load_project_settings,
     load_user_settings,
     normalize_input_path,
+    parse_file_size,
     resolve_db_dir,
     save_project_settings,
     save_user_settings,
@@ -684,3 +685,41 @@ def test_save_initial_writes_comment_template_for_unknown_litellm() -> None:
     # `dimensions` is intentionally NOT in the litellm template — it must be
     # the same on both sides, so we don't expose it as a per-side knob.
     assert "dimensions" not in content
+
+
+def test_parse_file_size_accepts_units_and_plain_bytes() -> None:
+    cases = [
+        (1048576, 1048576),
+        ("2048", 2048),
+        ("500KB", 500 * 1024),
+        ("500 kb", 500 * 1024),
+        ("1MB", 1024**2),
+        ("1.5MB", int(1.5 * 1024**2)),
+        ("2GB", 2 * 1024**3),
+        ("512B", 512),
+    ]
+    for raw, expected in cases:
+        assert parse_file_size(raw) == expected, raw
+
+
+def test_parse_file_size_rejects_invalid_values() -> None:
+    for raw in ["", "   ", "abc", "10XB", 0, -1, True, None, []]:
+        with pytest.raises(ValueError):
+            parse_file_size(raw)
+
+
+def test_project_settings_round_trip_max_file_size(tmp_path: Path) -> None:
+    save_project_settings(tmp_path, ProjectSettings(max_file_size=500 * 1024))
+    assert load_project_settings(tmp_path).max_file_size == 500 * 1024
+
+
+def test_project_settings_max_file_size_defaults_to_none(tmp_path: Path) -> None:
+    """Omitting the key keeps the previous behavior of indexing every size."""
+    save_project_settings(tmp_path, ProjectSettings())
+    assert load_project_settings(tmp_path).max_file_size is None
+
+
+def test_project_settings_parses_human_readable_max_file_size(tmp_path: Path) -> None:
+    path = save_project_settings(tmp_path, ProjectSettings())
+    path.write_text(path.read_text() + "\nmax_file_size: 500KB\n")
+    assert load_project_settings(tmp_path).max_file_size == 500 * 1024


### PR DESCRIPTION
Closes #179.

## Problem

`settings.yml` can only filter by glob, so keeping bundled or generated files out of the index means enumerating them in `exclude_patterns`. The issue describes a WordPress project where WooCommerce, Elementor, and LearnPress each ship minified `.js` bundles; there is no scalable pattern for "all of those, wherever they are, because they are large".

## Change

Adds an optional `max_file_size` to project settings:

```yaml
include_patterns:
  - "**/*.js"
exclude_patterns:
  - "**/node_modules"
max_file_size: 500KB
```

- **Value format** — a plain byte count (`1048576`) or a binary-unit suffix: `B`, `KB`, `MB`, `GB`, case-insensitive, fractional allowed (`1.5MB`). Parsing lives in `parse_file_size` and rejects empty, non-numeric, zero, negative, and `bool` values with a clear `ValueError`.
- **Where it applies** — a `SizeLimitedMatcher` wrapper in `file_walk.build_matcher`, so it composes with the existing glob and `.gitignore` layers and every consumer of the project's file matching picks it up from one place, rather than each walker growing its own size check. That means `ccc grep` skips the same files as the indexer; the module docstring already frames the matcher as the single source of truth for "which files count as part of the project", so I kept the setting on that side of the line. Happy to scope it to indexing only if you would rather grep stay size-blind.
- **Default** — omitting the key leaves `max_file_size` at `None` and behavior exactly as it is today.
- **Boundary** — the limit is inclusive, so a file of exactly `max_file_size` bytes is kept.

One deliberate call: a file that cannot be stat'd (broken symlink, a race with a delete) is left to the underlying matcher rather than dropped. A size limit should not be the thing that decides an unreadable file's fate, and silently dropping it would make the cap look like it had matched something it never measured.

`min_file_size` from the issue's "could also be useful" note is not included; it seemed better to land the requested filter first than to add a knob with no reported use case.

## Tests

`tests/test_file_walk.py`

- oversized files are dropped while the rest of the walk is intact
- the limit is inclusive at exactly `max_file_size` bytes
- an unstattable file (broken symlink) survives the cap

`tests/test_settings.py`

- `parse_file_size` table over units, spacing, case, fractions, and plain bytes
- `parse_file_size` rejects empty / non-numeric / zero / negative / `bool` / `None` / list
- round-trip of `max_file_size` through save and load
- omitting the key yields `None`
- a hand-written `max_file_size: 500KB` in the YAML parses to bytes

Negative control: unwiring `SizeLimitedMatcher` from `build_matcher` turns the two size-filtering walk tests red, so they do witness the behavior.

## Validation

Run against a venv without the `sentence-transformers` extra, since `torch` has no x86_64 macOS wheel on this host:

- `pytest tests/test_file_walk.py tests/test_settings.py` — 66 passed
- `pytest tests/ -m "not docker_e2e"` — 26 failed / 245 passed; the same 26 fail on an unmodified checkout in this environment (they need `sentence-transformers`), and the delta is +8, exactly the tests added here
- `ruff check .` — clean
- `ruff format --check src/ tests/` — clean (`README.md` is reported unformatted both before and after this change, so I left it alone)
- `mypy src/cocoindex_code/file_walk.py src/cocoindex_code/settings.py` — clean

## Docs

README's `settings.yml` section gains the key, the accepted formats, the inclusive-limit and default-off semantics, and a note that it applies to `ccc grep` too. The "after editing ..." list now mentions `max_file_size`, since it is a file-matching change with the same no-restart-needed workflow.

## AI assistance

Written with AI assistance (Claude). The design choice worth flagging for review is the one above: putting the cap in `build_matcher` rather than in the indexer, which is what makes it apply to `ccc grep` as well.
