### PR TITLE
fix(mcp): report our own version in the MCP handshake

### DIFF
--- a/src/cocoindex_code/server.py
+++ b/src/cocoindex_code/server.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from mcp.server.mcpserver import MCPServer
 from pydantic import BaseModel, Field
 
+from ._version import __version__
 from .settings import DaemonSettings, load_user_settings
 
 _MCP_INSTRUCTIONS = (
@@ -60,7 +61,7 @@ class SearchResultModel(BaseModel):
 
 def create_mcp_server(project_root: str) -> MCPServer:
     """Create a lightweight MCP server that delegates to the daemon."""
-    mcp = MCPServer("cocoindex-code", instructions=_MCP_INSTRUCTIONS)
+    mcp = MCPServer("cocoindex-code", instructions=_MCP_INSTRUCTIONS, version=__version__)
 
     @mcp.tool(
         name="search",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,7 @@ import pytest
 from mcp import Client
 
 from cocoindex_code import client as daemon_client
+from cocoindex_code._version import __version__
 from cocoindex_code.protocol import SearchResponse
 from cocoindex_code.server import create_mcp_server
 
@@ -29,3 +30,12 @@ async def test_mcp_server_uses_v2_protocol(monkeypatch: pytest.MonkeyPatch) -> N
         "offset": 0,
         "message": None,
     }
+
+
+async def test_mcp_server_reports_own_version() -> None:
+    """The handshake advertises our version, not the SDK's or an empty string."""
+    server = create_mcp_server(".")
+    async with Client(server, raise_exceptions=True) as client:
+        assert client.server_info is not None
+        assert client.server_info.name == "cocoindex-code"
+        assert client.server_info.version == __version__


### PR DESCRIPTION
Follow-up to #242.

`MCPServer`'s `version` parameter defaults to `""` and `create_mcp_server` never passed one, so the handshake advertises an empty `serverInfo.version` — Claude Code's `/mcp` and MCP Inspector show nothing.

This predates #242: v1's `FastMCP` took no `version` argument and filled the field with the SDK's own release, so the handshake reported `1.29.0`. #242 turned a wrong value into an empty one; this reports the right one.

It now passes `_version.__version__` — the same value `ccc version` prints (#245) and the daemon handshake compares against — so it can't drift. Single `MCPServer(...)` call site, so `ccc mcp` and the legacy `cocoindex-code` entry point both pick it up.

## Try it

```
$ uv run python -c "
import asyncio
from mcp import Client
from cocoindex_code.server import create_mcp_server
async def m():
    async with Client(create_mcp_server('.')) as c: print(repr(c.server_info.version))
asyncio.run(m())"

''                          # main @ 1a56d0f
'0.2.40.dev7+gc51a93e78'    # this branch, matching `ccc version`
```

`test_mcp_server_reports_own_version` asserts the handshake value equals `__version__`.

## Operational impact

None — handshake metadata only. No protocol, settings, or on-disk change; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
