### PR TITLE
fix(daemon): keep the socket path under the AF_UNIX limit

### DIFF
--- a/src/cocoindex_code/_daemon_paths.py
+++ b/src/cocoindex_code/_daemon_paths.py
@@ -6,14 +6,21 @@ can import these without pulling in the full daemon stack.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 import sys
+import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
 
 from .settings import user_settings_dir
+
+# Max bytes in sockaddr_un.sun_path, including the NUL terminator: 104 on the
+# BSDs (incl. macOS), 108 on Linux. Exceeding it makes bind() fail with
+# "AF_UNIX path too long" — unlike ordinary files, which get PATH_MAX (~1024).
+_SUN_PATH_MAX = 104 if sys.platform == "darwin" else 108
 
 
 def daemon_runtime_dir() -> Path:
@@ -39,18 +46,37 @@ def connection_family() -> str:
     return "AF_PIPE" if sys.platform == "win32" else "AF_UNIX"
 
 
-def daemon_socket_path() -> str:
-    """Return the daemon socket/pipe address."""
-    if sys.platform == "win32":
-        import hashlib
+def _runtime_dir_hash() -> str:
+    """Stable short id for the current runtime dir.
 
-        # Hash the runtime dir so COCOINDEX_CODE_RUNTIME_DIR (or the
-        # COCOINDEX_CODE_DIR fallback) overrides produce unique pipe names,
-        # preventing conflicts between different daemon instances (tests,
-        # users, etc.)
-        dir_hash = hashlib.md5(str(daemon_runtime_dir()).encode()).hexdigest()[:12]
-        return rf"\\.\pipe\cocoindex_code_{dir_hash}"
-    return str(daemon_runtime_dir() / "daemon.sock")
+    Distinguishes daemon instances that differ only by
+    ``COCOINDEX_CODE_RUNTIME_DIR`` / ``COCOINDEX_CODE_DIR``, so tests, users,
+    and containers never collide on one address.
+    """
+    return hashlib.md5(str(daemon_runtime_dir()).encode()).hexdigest()[:12]
+
+
+def daemon_socket_path() -> str:
+    """Return the daemon socket/pipe address.
+
+    Normally ``<runtime dir>/daemon.sock``. When that exceeds the platform's
+    ``sun_path`` limit — a deep ``$HOME``, a sandbox, a container path — it
+    would fail at bind() with a message that reads like a broken install, so
+    fall back to a short path under the temp dir keyed by the runtime dir.
+    Client and daemon both resolve through here, so they agree either way.
+    """
+    if sys.platform == "win32":
+        return rf"\\.\pipe\cocoindex_code_{_runtime_dir_hash()}"
+
+    path = daemon_runtime_dir() / "daemon.sock"
+    if len(str(path).encode()) < _SUN_PATH_MAX:
+        return str(path)
+
+    # gettempdir() honors $TMPDIR, which is per-user and private on macOS; on
+    # Linux it is usually shared /tmp, so include the uid to avoid a foreign
+    # socket sitting at our address.
+    short = Path(tempfile.gettempdir()) / f"ccc-{os.getuid()}-{_runtime_dir_hash()}.sock"
+    return str(short)
 
 
 def daemon_pid_path() -> Path:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import shutil
+import sys
+import tempfile
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -633,6 +636,66 @@ def test_daemon_runtime_dir_falls_back_to_user_settings_dir(
     monkeypatch.delenv("COCOINDEX_CODE_RUNTIME_DIR", raising=False)
     monkeypatch.setenv("COCOINDEX_CODE_DIR", str(settings_dir))
     assert daemon_runtime_dir() == settings_dir
+
+
+# ---------------------------------------------------------------------------
+# daemon_socket_path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="named pipes have no length limit")
+def test_daemon_socket_path_uses_runtime_dir_when_short(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The common case is unchanged: socket sits in the runtime dir.
+
+    Deliberately not pytest's ``tmp_path`` — on macOS that is ~118 bytes, past
+    sun_path already, which is how routine this overflow is.
+    """
+    from cocoindex_code._daemon_paths import daemon_socket_path
+
+    short_dir = tempfile.mkdtemp(prefix="ccc", dir=tempfile.gettempdir())
+    try:
+        monkeypatch.setenv("COCOINDEX_CODE_RUNTIME_DIR", short_dir)
+        assert daemon_socket_path() == str(Path(short_dir) / "daemon.sock")
+    finally:
+        shutil.rmtree(short_dir, ignore_errors=True)
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="named pipes have no length limit")
+def test_daemon_socket_path_falls_back_when_over_sun_path_limit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A deep runtime dir must not produce an unbindable socket address.
+
+    bind() fails with "AF_UNIX path too long" past sun_path (104 bytes on
+    macOS), which surfaces as a generic daemon-startup failure. Seen in the
+    wild under sandboxes and containers with long $HOME paths.
+    """
+    from cocoindex_code._daemon_paths import _SUN_PATH_MAX, daemon_socket_path
+
+    deep = tmp_path / ("d" * 80) / ("e" * 80)
+    monkeypatch.setenv("COCOINDEX_CODE_RUNTIME_DIR", str(deep))
+
+    path = daemon_socket_path()
+    assert not path.startswith(str(deep))
+    assert len(path.encode()) < _SUN_PATH_MAX
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="named pipes have no length limit")
+def test_daemon_socket_path_fallback_is_unique_per_runtime_dir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Two over-long runtime dirs must not collide on one socket address."""
+    from cocoindex_code._daemon_paths import daemon_socket_path
+
+    long_a = tmp_path / ("a" * 80) / ("x" * 80)
+    long_b = tmp_path / ("b" * 80) / ("y" * 80)
+
+    monkeypatch.setenv("COCOINDEX_CODE_RUNTIME_DIR", str(long_a))
+    first = daemon_socket_path()
+    monkeypatch.setenv("COCOINDEX_CODE_RUNTIME_DIR", str(long_b))
+    second = daemon_socket_path()
+
+    assert first != second
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The daemon socket lives at `<runtime dir>/daemon.sock`, but a unix socket address is capped at 104 bytes on macOS/BSD (108 on Linux) where ordinary files get ~1024. A deep runtime dir — long `$HOME`, sandbox, container, CI workspace — makes `bind()` fail with `OSError: AF_UNIX path too long`, which reaches the user as *"Daemon process exited before it became ready"* and reads like a broken install. A home directory ~72 bytes deep is enough, since `/.cocoindex_code/daemon.sock` adds 28.

When the natural path is over the limit, fall back to a short temp-dir address named `ccc-<uid>-<hash of runtime dir>.sock` — hashed so daemons differing only by `COCOINDEX_CODE_RUNTIME_DIR` keep distinct sockets, uid because `/tmp` is shared on Linux. Below the limit, nothing changes.

## Validation

Real output, using the runtime dir from a sandbox that hit this:

```
sun_path limit (macOS)  : 104
natural socket path     : /private/var/folders/nf/0rxqtdrs2hz89392pfrb31400000gn/T/claude-eval-y1pCn8/home/.cocoindex_code/daemon.sock
  length                : 108 bytes  -> OVER LIMIT (bind fails)
daemon_socket_path()    : /var/folders/nf/0rxqtdrs2hz89392pfrb31400000gn/T/ccc-501-a32f3a083724.sock
  length                : 74 bytes  -> bindable
```

Reproduce the original failure on macOS — fails before, starts after:

```bash
DEEP="$TMPDIR/$(python3 -c 'print("d"*90)')" && mkdir -p "$DEEP"
COCOINDEX_CODE_RUNTIME_DIR="$DEEP" ccc status
```

Worth knowing on review: the limit applies to the string passed to `bind()`, not the path after symlink resolution (verified directly — a 102-byte `/var/...` address binds even though it resolves to 110 under `/private`). So the check measures the unresolved string.

- `uv run pytest` — 298 passed, 3 new (short path unchanged, fallback under the limit, two over-long runtime dirs don't collide)
- `uv run prek run --all-files` — passed

## Operational impact

None — no migration, no config change, no new setting. A daemon already running keeps its socket, since it was under the limit or it would not have started. Windows named pipes are unaffected; that branch only shares the new hash helper.

Independent of #243 (daemon startup races) — different files, different failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
