### PR TITLE
feat(daemon): allow idle exit during MCP sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ The tool runs as a **long-lived background daemon** (`daemon.py`) that accepts c
 
 The daemon is auto-started by `client.py` when not running. It is restarted automatically when the `global_settings.yml` mtime changes (version bump or settings edit), detected via the `HandshakeResponse.global_settings_mtime_us` field.
 
-The daemon idle-exits after `daemon.idle_timeout_minutes` (default 180, 0 = never) without client activity, unless a live MCP session is sending heartbeats; clients transparently restart it on the next request. Graceful exits leave a `last_exit` marker file so the client can tell an expected exit from a crash (which triggers a loud restart, capped after consecutive crashes).
+The daemon idle-exits after `daemon.idle_timeout_minutes` (default 180, 0 = never) without client activity. A live MCP session sends heartbeats by default; users can set `daemon.keep_alive_with_mcp: false` to allow idle exit during a connected session. Clients transparently restart the daemon on the next real request. Graceful exits leave a `last_exit` marker file so the client can tell an expected exit from a crash (which triggers a loud restart, capped after consecutive crashes).
 
 ### Key Layers
 

--- a/README.md
+++ b/README.md
@@ -521,6 +521,7 @@ envs:                                                # extra environment variabl
 
 daemon:
   idle_timeout_minutes: 180                          # optional: exit the daemon after this long without client activity (default 180, 0 = never)
+  keep_alive_with_mcp: true                          # optional: keep the daemon warm while an MCP client is connected (default true)
 ```
 
 > **Note:** The daemon inherits your shell environment. If an API key (e.g. `OPENAI_API_KEY`) is already set as an environment variable, you don't need to duplicate it in `envs`. The `envs` field is only for values that aren't in your environment.
@@ -529,7 +530,7 @@ daemon:
 
 > **Indexing concurrency:** Multiple projects may prepare indexes concurrently, while CocoIndex serializes their GPU calls through its single MPS subprocess. A search waits only when its own project still needs the initial index.
 
-> **Idle timeout:** the background daemon holds the embedding model in RAM, so it exits after `daemon.idle_timeout_minutes` without client activity and is restarted automatically on your next `ccc` command or MCP search. A live MCP session sends periodic heartbeats, so the daemon never idles out while your coding agent is connected. Set `0` to keep the daemon running forever.
+> **Idle timeout:** the background daemon holds the embedding model in RAM, so it exits after `daemon.idle_timeout_minutes` without client activity and is restarted automatically on your next `ccc` command or MCP search. By default, a live MCP session sends periodic heartbeats so the daemon remains warm while your coding agent is connected. Set `daemon.keep_alive_with_mcp: false` to let the daemon idle-exit during long-lived MCP sessions and release the model between real requests. Set `idle_timeout_minutes: 0` to keep the daemon running forever.
 
 > **Custom location:** set `COCOINDEX_CODE_DIR` to place `global_settings.yml` somewhere other than `~/.cocoindex_code/` — useful if you want the file to live alongside your projects (e.g. on a synced folder).
 

--- a/skills/ccc/references/settings.md
+++ b/skills/ccc/references/settings.md
@@ -15,6 +15,10 @@ embedding:
 
 envs:                               # extra environment variables for the daemon
   OPENAI_API_KEY: your-key          # only needed if not already in the shell environment
+
+daemon:
+  idle_timeout_minutes: 180         # 0 keeps the daemon running forever
+  keep_alive_with_mcp: true         # false allows idle exit during live MCP sessions
 ```
 
 ### Fields
@@ -26,6 +30,8 @@ envs:                               # extra environment variables for the daemon
 | `embedding.device` | Optional. `cpu`, `cuda`, or `mps`. Auto-detected if omitted. Only relevant for `sentence-transformers`. |
 | `embedding.min_interval_ms` | Optional. Minimum delay between LiteLLM embedding requests in milliseconds. Defaults to `5` for LiteLLM and is ignored by `sentence-transformers`. Set explicitly to override the default. |
 | `envs` | Key-value map of environment variables injected into the daemon. Use for API keys not already in the shell environment. |
+| `daemon.idle_timeout_minutes` | Minutes without client activity before the daemon exits. Defaults to `180`; use `0` to disable idle exit. |
+| `daemon.keep_alive_with_mcp` | Whether a live MCP session keeps the daemon and embedding model warm. Defaults to `true`; set to `false` to release them after the normal idle timeout between real requests. |
 
 ### Embedding Model Examples
 

--- a/src/cocoindex_code/server.py
+++ b/src/cocoindex_code/server.py
@@ -174,23 +174,26 @@ def heartbeat_interval_s(idle_timeout_minutes: int) -> int:
 
 async def run_heartbeat_loop() -> None:
     """Periodically heartbeat the daemon so it never idle-exits under this
-    live MCP session; when this process dies (even SIGKILL) the heartbeats
-    stop and the daemon exits on its normal idle timeout.
+    live MCP session when ``daemon.keep_alive_with_mcp`` is enabled. When the
+    option is disabled, the daemon may idle-exit and the next real request
+    restarts it transparently. When this process dies (even SIGKILL), the
+    heartbeats stop and the daemon exits on its normal idle timeout.
 
     Reads the timeout from the same ``global_settings.yml`` the daemon reads
     (dataclass default when the file is missing or invalid). Returns
-    immediately when the timeout is 0 (daemon never idle-exits). The
-    heartbeat itself never starts or restarts a daemon — see
-    ``client.send_heartbeat``.
+    immediately when the timeout is 0 (daemon never idle-exits) or MCP
+    keep-alive is disabled. The heartbeat itself never starts or restarts a
+    daemon — see ``client.send_heartbeat``.
     """
-    from .client import send_heartbeat
-
     try:
-        timeout_minutes = load_user_settings().daemon.idle_timeout_minutes
+        daemon_settings = load_user_settings().daemon
     except (FileNotFoundError, ValueError):
-        timeout_minutes = DaemonSettings().idle_timeout_minutes
-    if timeout_minutes <= 0:
+        daemon_settings = DaemonSettings()
+    timeout_minutes = daemon_settings.idle_timeout_minutes
+    if timeout_minutes <= 0 or not daemon_settings.keep_alive_with_mcp:
         return
+
+    from .client import send_heartbeat
 
     interval = heartbeat_interval_s(timeout_minutes)
     loop = asyncio.get_event_loop()

--- a/src/cocoindex_code/settings.py
+++ b/src/cocoindex_code/settings.py
@@ -128,6 +128,8 @@ class DaemonSettings:
     # Minutes without client activity before the daemon exits (0 = never exit).
     # Clients auto-restart the daemon on the next request, so exiting is cheap.
     idle_timeout_minutes: int = 180
+    # Keep the daemon warm while a long-lived MCP client is connected.
+    keep_alive_with_mcp: bool = True
 
 
 @dataclass
@@ -466,8 +468,14 @@ def _user_settings_to_dict(settings: UserSettings) -> dict[str, Any]:
     d: dict[str, Any] = {"embedding": _embedding_settings_to_dict(settings.embedding)}
     if settings.envs:
         d["envs"] = dict(settings.envs)
-    if settings.daemon != DaemonSettings():
-        d["daemon"] = {"idle_timeout_minutes": settings.daemon.idle_timeout_minutes}
+    daemon_defaults = DaemonSettings()
+    daemon_dict: dict[str, Any] = {}
+    if settings.daemon.idle_timeout_minutes != daemon_defaults.idle_timeout_minutes:
+        daemon_dict["idle_timeout_minutes"] = settings.daemon.idle_timeout_minutes
+    if settings.daemon.keep_alive_with_mcp != daemon_defaults.keep_alive_with_mcp:
+        daemon_dict["keep_alive_with_mcp"] = settings.daemon.keep_alive_with_mcp
+    if daemon_dict:
+        d["daemon"] = daemon_dict
     return d
 
 
@@ -501,6 +509,11 @@ def _user_settings_from_dict(d: dict[str, Any]) -> UserSettings:
     daemon_kwargs: dict[str, Any] = {}
     if "idle_timeout_minutes" in daemon_dict:
         daemon_kwargs["idle_timeout_minutes"] = int(daemon_dict["idle_timeout_minutes"])
+    if "keep_alive_with_mcp" in daemon_dict:
+        keep_alive_with_mcp = daemon_dict["keep_alive_with_mcp"]
+        if not isinstance(keep_alive_with_mcp, bool):
+            raise ValueError("daemon.keep_alive_with_mcp must be a boolean")
+        daemon_kwargs["keep_alive_with_mcp"] = keep_alive_with_mcp
     daemon = DaemonSettings(**daemon_kwargs)
     return UserSettings(embedding=embedding, envs=envs, daemon=daemon)
 

--- a/tests/test_daemon_idle.py
+++ b/tests/test_daemon_idle.py
@@ -106,6 +106,24 @@ def test_heartbeat_interval_is_a_third_of_the_timeout_clamped() -> None:
     assert heartbeat_interval_s(180) == 300  # 3600 s → clamped down to 300 s
 
 
+@pytest.mark.asyncio
+async def test_heartbeat_loop_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    import cocoindex_code.server as server
+    from cocoindex_code.settings import DaemonSettings, EmbeddingSettings, UserSettings
+
+    settings = UserSettings(
+        embedding=EmbeddingSettings(provider="litellm", model="m"),
+        daemon=DaemonSettings(keep_alive_with_mcp=False),
+    )
+    monkeypatch.setattr(server, "load_user_settings", lambda: settings)
+
+    def unexpected_heartbeat() -> bool:
+        pytest.fail("disabled MCP keep-alive sent a heartbeat")
+
+    monkeypatch.setattr("cocoindex_code.client.send_heartbeat", unexpected_heartbeat)
+    await server.run_heartbeat_loop()
+
+
 # ---------------------------------------------------------------------------
 # In-process daemon E2E
 # ---------------------------------------------------------------------------

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -539,6 +539,7 @@ def test_daemon_settings_absent_section_uses_default(tmp_path: Path) -> None:
     path.write_text("embedding:\n  provider: litellm\n  model: m\n")
     loaded = load_user_settings()
     assert loaded.daemon.idle_timeout_minutes == 180
+    assert loaded.daemon.keep_alive_with_mcp is True
 
 
 @pytest.mark.usefixtures("_patch_user_dir")
@@ -550,6 +551,28 @@ def test_daemon_settings_parses_idle_timeout(tmp_path: Path) -> None:
     )
     loaded = load_user_settings()
     assert loaded.daemon.idle_timeout_minutes == 30
+
+
+@pytest.mark.usefixtures("_patch_user_dir")
+def test_daemon_settings_can_disable_mcp_keep_alive(tmp_path: Path) -> None:
+    path = tmp_path / ".cocoindex_code" / "global_settings.yml"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        "embedding:\n  provider: litellm\n  model: m\ndaemon:\n  keep_alive_with_mcp: false\n"
+    )
+    loaded = load_user_settings()
+    assert loaded.daemon.keep_alive_with_mcp is False
+
+
+@pytest.mark.parametrize("value", ["false", 0, None])
+def test_daemon_settings_rejects_non_boolean_mcp_keep_alive(value: object) -> None:
+    with pytest.raises(ValueError, match="keep_alive_with_mcp must be a boolean"):
+        _user_settings_from_dict(
+            {
+                "embedding": {"provider": "litellm", "model": "m"},
+                "daemon": {"keep_alive_with_mcp": value},
+            }
+        )
 
 
 @pytest.mark.usefixtures("_patch_user_dir")
@@ -567,11 +590,12 @@ def test_daemon_settings_explicit_zero_means_never(tmp_path: Path) -> None:
 def test_daemon_settings_round_trip() -> None:
     settings = UserSettings(
         embedding=EmbeddingSettings(provider="litellm", model="m"),
-        daemon=DaemonSettings(idle_timeout_minutes=45),
+        daemon=DaemonSettings(idle_timeout_minutes=45, keep_alive_with_mcp=False),
     )
     save_user_settings(settings)
     loaded = load_user_settings()
     assert loaded.daemon.idle_timeout_minutes == 45
+    assert loaded.daemon.keep_alive_with_mcp is False
 
 
 @pytest.mark.usefixtures("_patch_user_dir")


### PR DESCRIPTION
## Summary

- add `daemon.keep_alive_with_mcp`, defaulting to `true` for backward compatibility
- allow users to set it to `false` so the daemon can reach its normal idle timeout while an MCP client remains connected
- validate the setting as a strict YAML boolean and document it in the README and CCC skill reference

## Why

The MCP server currently sends daemon heartbeats for the lifetime of the MCP session. Long-lived editor and agent sessions therefore keep the daemon—and potentially its embedding model memory—resident even when no code search is happening.

With `keep_alive_with_mcp: false`, only the synthetic MCP heartbeat is disabled. Active requests, indexing, and the existing idle-timeout protections are unchanged. A later real request transparently starts the daemon again through the existing client path.

## Compatibility

The default remains `true`, so existing installations retain their current low-latency behavior unless users explicitly opt into idle exit.

## Validation

- `uv run prek run --all-files --verbose --show-diff-on-failure`
- 301 tests passed; 8 Docker end-to-end tests deselected
- Ruff, Ruff format, gitleaks, uv-lock, and mypy all passed
