### PR TITLE
fix(indexer): cap chunk length so an unsplittable line cannot OOM the daemon

### DIFF
--- a/src/cocoindex_code/indexer.py
+++ b/src/cocoindex_code/indexer.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import cocoindex as coco
 from cocoindex.connectors import localfs, sqlite
 from cocoindex.connectors.sqlite import Vec0TableDef
 from cocoindex.ops.text import RecursiveSplitter, detect_code_language
-from cocoindex.resources.chunk import Chunk
+from cocoindex.resources.chunk import Chunk, TextPosition
 from cocoindex.resources.id import IdGenerator
 
 from .chunking import CHUNKER_REGISTRY
@@ -22,6 +23,8 @@ from .shared import (
     CodeChunk,
 )
 
+logger = logging.getLogger(__name__)
+
 # Chunking configuration
 CHUNK_SIZE = 1000
 MIN_CHUNK_SIZE = 250
@@ -29,6 +32,82 @@ CHUNK_OVERLAP = 150
 
 # Chunking splitter (stateless, can be module-level)
 splitter = RecursiveSplitter()
+
+
+def _position_after(start: TextPosition, text: str) -> TextPosition:
+    """The position reached by reading *text* from *start*."""
+    newlines = text.count("\n")
+    if newlines:
+        # 1-based column, counting from the character after the last newline.
+        column = len(text) - text.rfind("\n")
+    else:
+        column = start.column + len(text)
+    # An oversized chunk is a packed array, base64 or minified code, so it is
+    # ASCII in practice — where the byte length is already known and encoding a
+    # copy of every piece just to measure it is waste.
+    byte_len = len(text) if text.isascii() else len(text.encode("utf-8"))
+    return TextPosition(
+        byte_offset=start.byte_offset + byte_len,
+        char_offset=start.char_offset + len(text),
+        line=start.line + newlines,
+        column=column,
+    )
+
+
+def cap_chunk_size(
+    chunks: list[Chunk],
+    limit: int = CHUNK_SIZE,
+    path: str | None = None,
+) -> list[Chunk]:
+    """Cut every chunk down to *limit* characters, keeping positions truthful.
+
+    `chunk_size` is a target the splitter cannot always meet: a line that holds
+    no separator it recognises comes back whole, however long it is. A Godot
+    `.tscn` stores a packed array as one 61k-character line, and that chunk
+    reached the embedder intact — which is fatal, because the embedder pads a
+    batch to its longest member and attention is quadratic in that length.
+    Measured on that one file: the daemon went from 0.8 GB to 106 GB of private
+    commit in three seconds and died with an empty log.
+
+    The default limit is CHUNK_SIZE itself, and not a multiple of it, for the
+    same quadratic reason — at 4x that file still peaked at 32 GB, because
+    `max_batch_size` is 64 upstream and 64 x 4000 characters is a batch no
+    consumer GPU holds. Everything downstream is sized for chunks of that
+    order, so the ceiling is simply the promise the pipeline already makes.
+
+    Applied to custom chunkers as well as to the splitter — a chunker that
+    returns the whole file as one chunk is a documented use, and it must not be
+    able to OOM the daemon either. Chunks already within the limit are returned
+    as they came, which is every chunk of every ordinary repository.
+    """
+    if all(len(chunk.text) <= limit for chunk in chunks):
+        return chunks
+
+    capped: list[Chunk] = []
+    for chunk in chunks:
+        length = len(chunk.text)
+        if length <= limit:
+            capped.append(chunk)
+            continue
+        logger.warning(
+            "Chunk of %d chars exceeds the %d-char ceiling%s — splitting it; "
+            "the source line is longer than the chunker can divide",
+            length,
+            limit,
+            f" in {path}" if path else "",
+        )
+        # Even pieces rather than limit-sized ones with a remainder: a tail of
+        # a few characters would be an embedding of noise, and nothing else in
+        # the pipeline emits a chunk below MIN_CHUNK_SIZE.
+        pieces = -(-length // limit)
+        size = -(-length // pieces)
+        start = chunk.start
+        for offset in range(0, length, size):
+            piece = chunk.text[offset : offset + size]
+            end = _position_after(start, piece)
+            capped.append(Chunk(text=piece, start=start, end=end))
+            start = end
+    return capped
 
 
 @coco.fn(memo=True)
@@ -72,6 +151,8 @@ async def process_file(
             chunk_overlap=CHUNK_OVERLAP,
             language=language,
         )
+
+    chunks = cap_chunk_size(chunks, path=file.file_path.path.as_posix())
 
     id_gen = IdGenerator()
 

--- a/tests/test_chunk_cap.py
+++ b/tests/test_chunk_cap.py
@@ -1,0 +1,165 @@
+"""The chunk-size ceiling: what protects the embedder from an unsplittable line.
+
+`RecursiveSplitter` treats `chunk_size` as a target, not a bound — a line with
+no separator it recognises comes back whole. A Godot `.tscn` stores a packed
+array as a single 61k-character line, and feeding that chunk to a long-context
+embedder is quadratic in attention: it took the daemon to 106 GB of commit and
+killed it. `cap_chunk_size` is the bound.
+"""
+
+from __future__ import annotations
+
+from cocoindex.resources.chunk import Chunk, TextPosition
+
+from cocoindex_code.indexer import (
+    CHUNK_OVERLAP,
+    CHUNK_SIZE,
+    MIN_CHUNK_SIZE,
+    cap_chunk_size,
+    splitter,
+)
+
+
+def _packed_array_line(values: int = 20_000) -> str:
+    """A line shaped like the one that kills the daemon: no separator to cut on.
+
+    Godot writes packed arrays this way, and so does any minifier. Generated
+    rather than committed as a fixture, so the test carries no 60 KB blob.
+    """
+    return '[sub_resource type="ArrayMesh"]\nsurfaces/0 = ' + ",".join(
+        str(i % 97) for i in range(values)
+    )
+
+
+def _chunk(text: str, *, line: int = 1, column: int = 1, char_offset: int = 0) -> Chunk:
+    start = TextPosition(
+        byte_offset=char_offset,
+        char_offset=char_offset,
+        line=line,
+        column=column,
+    )
+    end = TextPosition(
+        byte_offset=start.byte_offset + len(text.encode("utf-8")),
+        char_offset=start.char_offset + len(text),
+        line=line + text.count("\n"),
+        column=column + len(text),
+    )
+    return Chunk(text=text, start=start, end=end)
+
+
+def test_chunks_within_the_ceiling_are_returned_unchanged() -> None:
+    chunks = [_chunk("a" * 10), _chunk("b" * CHUNK_SIZE)]
+
+    assert cap_chunk_size(chunks) is chunks
+
+
+def test_an_oversized_chunk_is_cut_into_even_pieces() -> None:
+    # A remainder-sized tail would be an embedding of noise, so the pieces are
+    # evened out instead: 2007 characters become three of 669, not 1000/1000/7.
+    text = "x" * (CHUNK_SIZE * 2 + 7)
+
+    capped = cap_chunk_size([_chunk(text)])
+
+    assert len(capped) == 3
+    assert all(len(c.text) <= CHUNK_SIZE for c in capped)
+    assert all(len(c.text) >= MIN_CHUNK_SIZE for c in capped)
+    assert "".join(c.text for c in capped) == text
+
+
+def test_the_smallest_oversized_chunk_still_clears_the_minimum() -> None:
+    # One character over the ceiling is the worst case for an even split.
+    capped = cap_chunk_size([_chunk("x" * (CHUNK_SIZE + 1))])
+
+    assert len(capped) == 2
+    assert all(MIN_CHUNK_SIZE <= len(c.text) <= CHUNK_SIZE for c in capped)
+
+
+def test_pieces_carry_positions_forward() -> None:
+    # Two lines, the first long enough to force a cut inside it.
+    head = "y" * (CHUNK_SIZE + 3)
+    text = head + "\nsecond"
+
+    capped = cap_chunk_size([_chunk(text)])
+
+    assert len(capped) == 2
+    first, second = capped
+    assert first.start.line == 1
+    assert first.start.char_offset == 0
+    # The cut lands inside line 1, so the next piece still starts on line 1.
+    assert second.start.line == 1
+    assert second.start.char_offset == len(first.text)
+    # The tail spans the newline and ends on line 2.
+    assert second.end.line == 2
+    assert second.end.column == len("second") + 1
+    assert second.end.char_offset == len(text)
+
+
+def test_byte_offsets_count_bytes_not_characters() -> None:
+    # Two bytes per character, so the byte offsets run ahead of the char ones.
+    text = "д" * (CHUNK_SIZE + 1)
+
+    capped = cap_chunk_size([_chunk(text)])
+
+    assert len(capped) == 2
+    assert capped[1].start.byte_offset == len(capped[0].text) * 2
+    assert capped[1].end.byte_offset == len(text.encode("utf-8"))
+
+
+def test_a_custom_limit_is_honoured() -> None:
+    capped = cap_chunk_size([_chunk("z" * 10)], limit=4)
+
+    assert len(capped) == 3
+    assert all(len(c.text) <= 4 for c in capped)
+    assert "".join(c.text for c in capped) == "z" * 10
+
+
+def test_the_real_pathological_shape_is_bounded() -> None:
+    # One 61k-character line, the shape that killed the daemon.
+    text = "p" * 60_942
+
+    capped = cap_chunk_size([_chunk(text)])
+
+    assert max(len(c.text) for c in capped) <= CHUNK_SIZE
+    assert min(len(c.text) for c in capped) >= MIN_CHUNK_SIZE
+    assert "".join(c.text for c in capped) == text
+
+
+# --- against the real splitter ----------------------------------------------
+# The tests above drive cap_chunk_size directly, so they would still pass if
+# the call disappeared from process_file. These two pin the actual pipeline:
+# the first records what the splitter really does with such a line (and fails
+# loudly if that ever changes), the second is the regression that matters.
+
+
+def test_the_splitter_really_does_exceed_its_own_chunk_size() -> None:
+    content = _packed_array_line()
+
+    chunks = splitter.split(
+        content,
+        chunk_size=CHUNK_SIZE,
+        min_chunk_size=MIN_CHUNK_SIZE,
+        chunk_overlap=CHUNK_OVERLAP,
+        language="text",
+    )
+
+    assert max(len(c.text) for c in chunks) > CHUNK_SIZE * 10
+
+
+def test_splitter_output_is_bounded_once_capped() -> None:
+    content = _packed_array_line()
+
+    chunks = cap_chunk_size(
+        splitter.split(
+            content,
+            chunk_size=CHUNK_SIZE,
+            min_chunk_size=MIN_CHUNK_SIZE,
+            chunk_overlap=CHUNK_OVERLAP,
+            language="text",
+        )
+    )
+
+    assert max(len(c.text) for c in chunks) <= CHUNK_SIZE
+    # Positions stay inside the document they describe.
+    assert chunks[0].start.char_offset == 0
+    assert max(c.end.char_offset for c in chunks) <= len(content)
+    assert all(c.start.line >= 1 and c.start.column >= 1 for c in chunks)

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -21,6 +21,7 @@ from typer.testing import CliRunner
 
 from cocoindex_code.cli import app
 from cocoindex_code.client import stop_daemon
+from cocoindex_code.indexer import CHUNK_SIZE
 from cocoindex_code.settings import (
     _reset_db_path_mapping_cache,
     default_project_settings,
@@ -342,6 +343,35 @@ def test_session_respects_gitignore(e2e_project: Path) -> None:
     assert "ignored.py" not in file_paths
     assert "ignored_dir/nested.py" not in file_paths
     assert "important.py" in file_paths
+
+
+def test_session_caps_oversized_chunks(e2e_project: Path) -> None:
+    """A line the splitter cannot divide must not reach the embedder whole.
+
+    `chunk_size` is a target, not a bound: a line with no separator comes back
+    as one chunk. Feeding a 58k-character chunk to a long-context embedder is
+    quadratic in attention and took a daemon to 106 GB of commit before it was
+    killed, so the row that lands in the index is the thing worth asserting on.
+    """
+    packed = ",".join(str(i % 97) for i in range(20_000))
+    (e2e_project / "packed.py").write_text(f'PACKED = "{packed}"\n')
+
+    runner.invoke(app, ["init"], catch_exceptions=False)
+    result = runner.invoke(app, ["index"], catch_exceptions=False)
+    assert result.exit_code == 0, result.output
+
+    db_path = e2e_project / ".cocoindex_code" / "target_sqlite.db"
+    conn = coco_sqlite.connect(str(db_path), load_vec=True)
+    try:
+        with conn.readonly() as db:
+            longest = db.execute(
+                "SELECT MAX(LENGTH(content)) FROM code_chunks_vec WHERE file_path = 'packed.py'"
+            ).fetchone()[0]
+    finally:
+        conn.close()
+
+    assert longest is not None, "the file with the long line was not indexed at all"
+    assert longest <= CHUNK_SIZE
 
 
 @pytest.mark.usefixtures("e2e_project")


### PR DESCRIPTION
## Problem

`RecursiveSplitter` treats `chunk_size` as a target, not a bound. A line containing no separator it
recognises comes back as one chunk, however long the line is, and `process_file` hands that chunk
straight to `embedder.embed()`.

That is fatal rather than wasteful. `SentenceTransformerEmbedder._embed` batches up to 64 texts and
pads the batch to its longest member, and attention costs O(n²) in that length. A 60,000-character
chunk is not 60x a normal one, it is thousands of times the memory.

Where it showed up: a Godot project. `.tscn` scene files store packed arrays — vertices, polygons,
navigation meshes — as a single line, and a mid-sized scene reaches 60,000 characters on one line
easily. Nothing about the bug is Godot-specific, though: minified JS or CSS, a long JSON literal, a
base64 blob or a generated lookup table all take the same path.

## How it surfaced

The report was "indexing hangs, then eats all the RAM", and `daemon.log` ended mid-session with no
traceback, because the process is killed before anything is written. What made it findable:

1. Sampling the daemon process rather than watching it. Private commit is the number that moves; RSS
   stays modest because most of the growth never becomes resident before the kill.
2. Narrowing by input. The repository held 5.7 MB of indexed text — small — so size was not the
   trigger. Indexing files individually put the whole failure on one 472 KB scene file: 0.8 GB → 106
   GB of commit in three seconds, dead process.
3. Running the chunker alone on that file, no daemon and no GPU. It returned a chunk of 60,942
   characters from a splitter asked for 1,000. Every other chunk in that repository and in a second,
   unrelated one measured at most 1,000, so this was the single input out of contract.

Reproduction, deterministic and instant:

```python
from cocoindex.ops.text import RecursiveSplitter

content = "surfaces/0 = " + ",".join(str(i % 97) for i in range(20_000))
chunks = RecursiveSplitter().split(
    content, chunk_size=1000, min_chunk_size=250, chunk_overlap=150, language="text"
)
print(len(chunks), max(len(c.text) for c in chunks))
# 2 57929   <- a 57,929-character chunk out of a splitter asked for 1000
```

Write that string into a file inside an indexed project and `ccc index` reproduces the crash end to
end.

## Fix

`cap_chunk_size()` cuts every chunk down to `limit`, defaulting to `CHUNK_SIZE`, and carries line,
column, character and byte offsets forward so the pieces still report where they came from. When
nothing is oversized it returns the input list unchanged, so the ordinary path allocates nothing.

- Applied after the custom-chunker branch too: returning a whole file as one chunk is a documented
  use of `CHUNKER_REGISTRY`, and that should not be able to kill the daemon either.
- Pieces are evened out rather than cut at the limit with a remainder — 2007 characters become three
  of 669, not `1000, 1000, 7`. A seven-character tail would be an embedding of noise, and nothing
  else in the pipeline emits a chunk below `MIN_CHUNK_SIZE`.
- The ceiling is `CHUNK_SIZE` and not a multiple of it: at `CHUNK_SIZE * 4` the same file still
  peaked at 32 GB, since with `max_batch_size=64` four times the sequence length is sixteen times the
  attention matrix.

## Validation

Windows 11, RTX 5090, `nomic-ai/CodeRankEmbed` on `cuda:0`, 61.6 GB RAM. Peak is private commit.

| Workload | Before | After | Peak commit |
|---|---|---|---|
| One 472 KB scene file, 60,942-character line | daemon killed, empty log | 539 chunks, 16 s | 106 GB → 11 GB |
| 413-file project containing that file | daemon killed mid-run | 9,811 chunks, 22 s | 76 GB → 14.7 GB |
| 210-file Python corpus, no oversized chunk | 3,227 chunks, 9.7 s | 3,227 chunks, 9.7 s | unchanged |

The third row is the control: with nothing over the ceiling the run is identical, which is what the
early return guarantees.

Tests are at three levels, since a unit test on `cap_chunk_size` alone would still pass if the call
were dropped from `process_file`:

- `tests/test_chunk_cap.py`, 7 unit cases: pass-through, the even cut, the worst case for evening out
  (one character over the ceiling), position carry-over across a newline, byte offsets on multi-byte
  text, a caller-supplied limit, and the real 60,942-character shape.
- 2 cases against the real `RecursiveSplitter`. One asserts that it *does* exceed its own
  `chunk_size` on such a line, so if that is fixed upstream this test fails and reports the cap as
  dead code instead of leaving it in place forever.
- `tests/test_e2e.py::test_session_caps_oversized_chunks`: a full `init` + `index` run, asserting no
  row in the index exceeds `CHUNK_SIZE`. Checked by disabling the call, where it fails with
  `assert 57929 <= 1000`. Adds about 8 s to the suite.

`uv run pytest` — 326 passed, 5 skipped, 8 deselected. `uv run prek run --all-files` — clean.
(`test_file_walk.py::test_max_file_size_keeps_unstattable_files` fails on my machine on `main` as
well: it creates a symlink and Windows refuses without the privilege, `WinError 1314`.)

## Compatibility

No configuration, no migration, no API change. Chunk IDs change only for files that previously
produced an oversized chunk, since those become several rows — such files reindex once and become
searchable at a useful granularity, which they were not before.

## Notes for reviewers

- The root cause is one level down: `RecursiveSplitter` could fall back to a hard character cut when
  it runs out of separators, and then no consumer would need this. I put the fix here because this is
  where the ceiling is known and where the crash lands, but I am happy to move it into the engine
  instead, or to open the issue there — say which you prefer.
- The ceiling is deliberately not a setting: it is `CHUNK_SIZE`, already the pipeline's chunk
  contract, and a separate knob would invite a value that reintroduces the crash. `limit` stays a
  parameter only so the tests can drive it.
- The warning fires once per oversized chunk, so a file with many such lines produces a burst. Happy
  to fold it into one line per file if you prefer.