### PR TITLE
feat(omp): session-start and post-edit index hooks

### DIFF
--- a/.omp-plugin/marketplace.json
+++ b/.omp-plugin/marketplace.json
@@ -10,7 +10,7 @@
     {
       "name": "cocoindex-code",
       "source": "./",
-      "description": "Semantic code search — ccc skill and MCP server (`ccc mcp`). Claude/Grok also ship an optional SessionStart index hook.",
+      "description": "Semantic code search — ccc skill, MCP server (`ccc mcp`), and index hooks (session start + post-edit).",
       "category": "development",
       "tags": [
         "semantic-search",

--- a/.omp-plugin/plugin.json
+++ b/.omp-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cocoindex-code",
   "version": "1.0.0",
-  "description": "AST-based semantic code search via the ccc CLI. Bundles the ccc skill; Grok installs also activate a SessionStart index hook and MCP server (disable either for skill-only).",
+  "description": "AST-based semantic code search via the ccc CLI. Bundles the ccc skill, MCP server, and index hooks (session start + post-edit).",
   "author": {
     "name": "CocoIndex",
     "email": "hi@cocoindex.io"

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ For [Grok](https://github.com/xai-org/grok) users, install via Grok's plugin sys
 | Component | Purpose |
 |-----------|---------|
 | **Skill** (`skills/ccc/`) | Agent runs `ccc search` / `ccc index` via the CLI (same as Claude Code above) |
-| **Hook** (`hooks/hooks.json`) | `SessionStart` → incremental `ccc index` when `.cocoindex_code/` exists |
+| **Hook** (`hooks/hooks.json`) | `SessionStart` + `PostToolUse` (Edit/Write/…) → incremental `ccc index` when `.cocoindex_code/` exists |
 | **MCP** (`.mcp.json`) | `ccc mcp` stdio server — `search` tool with `refresh_index=true` by default |
 
 Grok does **not** import Claude's `enabledPlugins` or plugin cache; install separately even if you already use cocoindex in Claude Code.
@@ -118,7 +118,7 @@ Prefer the GitHub shorthand (`cocoindex-io/cocoindex-code`) for install — `gro
 
 Install and enable as above, then disable the optional components:
 
-1. **Hooks** — open `/hooks`, select the `SessionStart` hook from `cocoindex-code`, press `Space` to disable.
+1. **Hooks** — open `/hooks`, select the `SessionStart` / `PostToolUse` hooks from `cocoindex-code`, press `Space` to disable.
 2. **MCP** — open `/mcps`, select `cocoindex-code`, press `Space` to disable; or persist in `~/.grok/config.toml`:
 
 ```toml
@@ -147,9 +147,17 @@ omp plugin marketplace add cocoindex-io/cocoindex-code
 omp plugin install cocoindex-code@cocoindex-code --scope project
 ```
 
-Then `/reload-plugins` (or restart the session). The plugin loads the `ccc` skill and the bundled MCP server (`ccc mcp`). Requires `ccc` on `PATH` (`uv tool install --upgrade 'cocoindex-code[full]'`).
+Then restart the session (`/reload-plugins` does not reload extensions). Requires `ccc` on `PATH` (`uv tool install --upgrade 'cocoindex-code[full]'`).
 
-Skill-only (no MCP): install the skill via `npx skills add cocoindex-io/cocoindex-code`, or run `ccc search` / `ccc index` from the shell.
+| Component | Purpose |
+|-----------|---------|
+| **Skill** (`skills/ccc/`) | Agent runs `ccc search` / `ccc index` via the CLI |
+| **Hook** (`extensions/ccc-index.ts` via `package.json#omp.extensions`) | `session_start` + post-edit `tool_result` → incremental `ccc index` when `.cocoindex_code/` exists |
+| **MCP** (`.mcp.json`) | `ccc mcp` stdio server |
+
+OMP does **not** execute Claude `hooks/hooks.json` command hooks. The TypeScript extension is the OMP equivalent of the Claude/Grok SessionStart + PostToolUse pair.
+
+Skill-only (no MCP, no auto-index): install the skill via `npx skills add cocoindex-io/cocoindex-code`, or run `ccc search` / `ccc index` from the shell.
 
 ### MCP Server
 

--- a/extensions/ccc-index.ts
+++ b/extensions/ccc-index.ts
@@ -1,0 +1,112 @@
+/**
+ * Oh My Pi extension — same contract as Claude/Grok hooks/hooks.json:
+ *   session_start              → incremental `ccc index` if the project is initialized
+ *   tool_result after edits    → same (Edit/Write/MultiEdit/search_replace + OMP names)
+ *
+ * Fail-open: missing `ccc`, missing `.cocoindex_code/`, or a failed index never
+ * throws into the session.
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const INDEX_TIMEOUT_MS = 60_000;
+
+const EDIT_TOOLS: Record<string, true> = {
+  edit: true,
+  write: true,
+  ast_edit: true,
+  multiedit: true,
+  search_replace: true,
+};
+
+type IndexCtx = { cwd: string };
+
+type ToolResultEvent = {
+  toolName?: string;
+  isError?: boolean;
+};
+
+type ExtensionApi = {
+  setLabel?: (label: string) => void;
+  on: (
+    event: string,
+    handler: (event: ToolResultEvent, ctx: IndexCtx) => unknown,
+  ) => void;
+};
+
+function findInitializedRoot(cwd: string): string | null {
+  let dir = cwd;
+  for (let i = 0; i < 32; i++) {
+    if (existsSync(join(dir, ".cocoindex_code"))) {
+      return dir;
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+  return null;
+}
+
+function runIndex(root: string): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  const child = spawn("ccc", ["index"], {
+    cwd: root,
+    stdio: "ignore",
+  });
+  const timer = setTimeout(() => {
+    child.kill("SIGTERM");
+    resolve();
+  }, INDEX_TIMEOUT_MS);
+  const done = () => {
+    clearTimeout(timer);
+    resolve();
+  };
+  child.on("error", done);
+  child.on("close", done);
+  return promise;
+}
+
+export default function cccIndex(pi: ExtensionApi): void {
+  pi.setLabel?.("ccc-index");
+
+  let running = false;
+  let queued = false;
+
+  const reindex = async (ctx: IndexCtx): Promise<void> => {
+    if (running) {
+      queued = true;
+      return;
+    }
+    running = true;
+    try {
+      do {
+        queued = false;
+        const root = findInitializedRoot(ctx.cwd);
+        if (root) {
+          await runIndex(root);
+        }
+      } while (queued);
+    } finally {
+      running = false;
+    }
+  };
+
+  pi.on("session_start", async (_event, ctx) => {
+    await reindex(ctx);
+  });
+
+  pi.on("tool_result", async (event, ctx) => {
+    if (event.isError) {
+      return;
+    }
+    const name = String(event.toolName ?? "").toLowerCase();
+    if (!EDIT_TOOLS[name]) {
+      return;
+    }
+    await reindex(ctx);
+  });
+}

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,19 @@
           {
             "type": "command",
             "timeout": 60,
-            "command": "command -v ccc >/dev/null && test -d \"${CLAUDE_PROJECT_DIR}/.cocoindex_code\" && (cd \"${CLAUDE_PROJECT_DIR}\" && ccc index) 2>/dev/null || true"
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-${GROK_WORKSPACE_ROOT:-}}\"; [ -z \"$root\" ] && root=\"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\"; command -v ccc >/dev/null && test -d \"$root/.cocoindex_code\" && (cd \"$root\" && ccc index) 2>/dev/null || true"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit|search_replace",
+        "hooks": [
+          {
+            "type": "command",
+            "timeout": 30,
+            "command": "root=\"${CLAUDE_PROJECT_DIR:-${GROK_WORKSPACE_ROOT:-}}\"; [ -z \"$root\" ] && root=\"$(git rev-parse --show-toplevel 2>/dev/null || pwd)\"; command -v ccc >/dev/null && test -d \"$root/.cocoindex_code\" && (cd \"$root\" && ccc index) 2>/dev/null || true"
           }
         ]
       }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "cocoindex-code",
+  "version": "1.0.0",
+  "private": true,
+  "description": "OMP extension host for cocoindex-code (ccc index hooks).",
+  "license": "Apache-2.0",
+  "omp": {
+    "extensions": ["./extensions/ccc-index.ts"]
+  }
+}

--- a/tests/test_omp_plugin_manifests.py
+++ b/tests/test_omp_plugin_manifests.py
@@ -1,4 +1,4 @@
-"""OMP marketplace/plugin manifests stay valid and launch `ccc mcp`."""
+"""OMP marketplace/plugin manifests stay valid, launch `ccc mcp`, and declare index hooks."""
 
 from __future__ import annotations
 
@@ -22,3 +22,23 @@ def test_omp_plugin_manifest_replaces_mcp_with_ccc_mcp() -> None:
     assert manifest["mcpServers"] == "./.mcp.json"
     mcp = json.loads((REPO_ROOT / ".mcp.json").read_text())
     assert mcp["mcpServers"]["cocoindex-code"] == {"command": "ccc", "args": ["mcp"]}
+
+
+def test_omp_package_declares_ccc_index_extension() -> None:
+    package = json.loads((REPO_ROOT / "package.json").read_text())
+    entries = package["omp"]["extensions"]
+    assert entries == ["./extensions/ccc-index.ts"]
+    extension = REPO_ROOT / "extensions" / "ccc-index.ts"
+    assert extension.is_file()
+    source = extension.read_text()
+    assert 'pi.on("session_start"' in source
+    assert 'pi.on("tool_result"' in source
+
+
+def test_claude_hooks_cover_session_start_and_post_edit() -> None:
+    hooks = json.loads((REPO_ROOT / "hooks" / "hooks.json").read_text())["hooks"]
+    assert "SessionStart" in hooks
+    assert "PostToolUse" in hooks
+    matcher = hooks["PostToolUse"][0]["matcher"]
+    assert "Edit" in matcher
+    assert "Write" in matcher


### PR DESCRIPTION
## Description

Oh My Pi does not execute Claude `hooks/hooks.json` command hooks. This adds the missing OMP equivalent of the SessionStart + PostToolUse pair, and the matching Grok/Claude PostToolUse hook.

- `extensions/ccc-index.ts` via `package.json#omp.extensions`: fail-open `ccc index` on `session_start` and after edit `tool_result` (Edit/Write/MultiEdit/search_replace + OMP names) when `.cocoindex_code/` exists.
- `hooks/hooks.json`: keep SessionStart, add PostToolUse; resolve project root from `CLAUDE_PROJECT_DIR` / `GROK_WORKSPACE_ROOT` / git toplevel.
- README: document the OMP extension (restart required; `/reload-plugins` does not reload extensions) and Grok PostToolUse.

## Motivation

Upstream already ships the OMP marketplace catalog (#277) with skill + MCP. Without the TypeScript extension, OMP never auto-indexes after edits. Grok/Claude only reindexed on session start.

## Breaking change

No.

## Related

Follow-up to https://github.com/cocoindex-io/cocoindex-code/pull/277.
